### PR TITLE
Hoist monorepo internal packages so we can publish a snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,4 @@ jobs:
           publish: pnpm ci:publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -153,16 +153,6 @@ function standardPackageRules(shared) {
         ),
       },
     }),
-    requireDependency({
-      ...shared,
-      options: {
-        devDependencies: {
-          mytsup: "workspace:*",
-          "eslint-config-sane": "workspace:*",
-          tsconfig: "workspace:*",
-        },
-      },
-    }),
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "tsc-absolute": "^1.0.1",
     "tsup": "^7.2.0",
     "turbo": "^1.10.13",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "eslint-config-sane": "workspace:*",
+    "mytsup": "workspace:*",
+    "tsconfig": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "dprint": "^0.41.0",
     "esbuild-plugin-babel": "^0.2.3",
     "eslint": "^8.49.0",
+    "eslint-config-sane": "workspace:*",
     "find-up-cli": "^5.0.0",
+    "mytsup": "workspace:*",
     "tsc-absolute": "^1.0.1",
+    "tsconfig": "workspace:*",
     "tsup": "^7.2.0",
     "turbo": "^1.10.13",
-    "typescript": "^5.2.2",
-    "eslint-config-sane": "workspace:*",
-    "mytsup": "workspace:*",
-    "tsconfig": "workspace:*"
+    "typescript": "^5.2.2"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,10 +29,7 @@
     "tiny-invariant": "^1.3.1"
   },
   "devDependencies": {
-    "eslint-config-sane": "workspace:*",
-    "mytsup": "workspace:*",
     "ts-expect": "^1.3.0",
-    "tsconfig": "workspace:*",
     "typescript": "^5.2.2"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,21 @@ importers:
       eslint:
         specifier: ^8.49.0
         version: 8.49.0
+      eslint-config-sane:
+        specifier: workspace:*
+        version: link:monorepo/eslint-config-sane
       find-up-cli:
         specifier: ^5.0.0
         version: 5.0.0
+      mytsup:
+        specifier: workspace:*
+        version: link:monorepo/mytsup
       tsc-absolute:
         specifier: ^1.0.1
         version: 1.0.1(typescript@5.2.2)
+      tsconfig:
+        specifier: workspace:*
+        version: link:monorepo/tsconfig
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(typescript@5.2.2)
@@ -164,18 +173,9 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
     devDependencies:
-      eslint-config-sane:
-        specifier: workspace:*
-        version: link:../../monorepo/eslint-config-sane
-      mytsup:
-        specifier: workspace:*
-        version: link:../../monorepo/mytsup
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
-      tsconfig:
-        specifier: workspace:*
-        version: link:../../monorepo/tsconfig
       typescript:
         specifier: ^5.2.2
         version: 5.2.2


### PR DESCRIPTION
Tweaks to support publishing snapshots
* Hoist internal packages so they aren't listed as dev-dependencies
* Provide the release workflow access to the GITHUB_TOKEN for creating the release PR.