### PR TITLE
Workflow improvements

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,7 @@
   "updateInternalDependencies": "patch",
   "ignore": [],
   "bumpVersionsWithWorkspaceProtocolOnly": true,
-  "useCalculatedVersion": true
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ yarn-error.log*
 
 dist/
 lib/
+types/
+build/
 tsconfig.tsbuildinfo

--- a/dprint.json
+++ b/dprint.json
@@ -8,8 +8,7 @@
   "toml": {},
   "excludes": [
     "**/*-lock.json",
-    "**/lib",
-    "**/dist",
+    "**/build",
     "**/.turbo",
     "pnpm-lock.yaml",
     ".vscode/settings.json"

--- a/examples/basic/cli/package.json
+++ b/examples/basic/cli/package.json
@@ -4,23 +4,24 @@
   "license": "Apache-2.0",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./build/types/index.d.ts",
+      "import": "./build/js/index.mjs",
+      "require": "./build/js/index.js"
     },
     "./*": {
-      "types": "./src/public/*.ts",
-      "import": "./dist/public/*.mjs",
-      "require": "./dist/public/*.js"
+      "types": "./build/types/public/*.d.ts",
+      "import": "./build/js/public/*.mjs",
+      "require": "./build/js/public/*.js"
     }
   },
   "scripts": {
-    "build": "tsup",
-    "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
-    "dev": "tsup --watch",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "dev:transpile": "tsup --watch",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "prettier": "prettier .",
-    "typecheck": "tsc-absolute"
+    "transpile": "tsup",
+    "transpileWatch": "tsup --watch",
+    "typecheck": "tsc-absolute --build"
   },
   "dependencies": {
     "@osdk/api": "workspace:*",
@@ -29,12 +30,15 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "eslint-config-sane": "workspace:*",
-    "mytsup": "workspace:*",
-    "ts-expect": "^1.3.0",
-    "tsconfig": "workspace:*"
+    "ts-expect": "^1.3.0"
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "types",
+    "CHANGELOG.md",
+    "package.json"
+  ]
 }

--- a/examples/basic/cli/tsconfig.json
+++ b/examples/basic/cli/tsconfig.json
@@ -1,5 +1,20 @@
 {
   "extends": "tsconfig/base",
-  "compilerOptions": { "rootDir": "src", "outDir": "lib" },
-  "include": ["./src/**/*", ".eslintrc.cjs"]
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/types",
+    "composite": true
+  },
+  "include": [
+    "./src/**/*",
+    ".eslintrc.cjs"
+  ],
+  "references": [
+    {
+      "path": "../../../packages/api"
+    },
+    {
+      "path": "../sdk"
+    }
+  ]
 }

--- a/examples/basic/cli/tsup.json
+++ b/examples/basic/cli/tsup.json
@@ -1,9 +1,0 @@
-{
-  "entry": ["src/index.ts"],
-  "format": ["cjs", "esm"],
-  "dts": true,
-  "clean": true,
-  "sourcemap": true,
-  "splitting": true,
-  "target": "es2022"
-}

--- a/examples/basic/sdk/package.json
+++ b/examples/basic/sdk/package.json
@@ -6,35 +6,39 @@
   "license": "Apache-2.0",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./build/types/index.d.ts",
+      "import": "./build/js/index.mjs",
+      "require": "./build/js/index.js"
     },
     "./*": {
-      "types": "./src/public/*.ts",
-      "import": "./dist/public/*.mjs",
-      "require": "./dist/public/*.js"
+      "types": "./build/types/public/*.d.ts",
+      "import": "./build/js/public/*.mjs",
+      "require": "./build/js/public/*.js"
     }
   },
   "scripts": {
-    "build": "tsup",
-    "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
-    "dev": "tsup --watch",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "dev:transpile": "tsup --watch",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "prettier": "prettier .",
-    "typecheck": "tsc-absolute"
+    "transpile": "tsup",
+    "transpileWatch": "tsup --watch",
+    "typecheck": "tsc-absolute --build"
   },
   "dependencies": {
     "@osdk/api": "workspace:*"
   },
   "devDependencies": {
-    "eslint-config-sane": "workspace:*",
-    "mytsup": "workspace:*",
-    "tsconfig": "workspace:*",
     "typescript": "^5.2.2"
   },
   "publishConfig": {
     "access": "public"
   },
-  "keywords": []
+  "keywords": [],
+  "files": [
+    "dist",
+    "types",
+    "CHANGELOG.md",
+    "package.json"
+  ]
 }

--- a/examples/basic/sdk/tsconfig.json
+++ b/examples/basic/sdk/tsconfig.json
@@ -1,5 +1,17 @@
 {
   "extends": "tsconfig/base",
-  "compilerOptions": { "rootDir": "src", "outDir": "lib" },
-  "include": ["./src/**/*", ".eslintrc.cjs"]
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/types",
+    "composite": true
+  },
+  "include": [
+    "./src/**/*",
+    ".eslintrc.cjs"
+  ],
+  "references": [
+    {
+      "path": "../../../packages/api"
+    }
+  ]
 }

--- a/monorepo/eslint-config-sane/library.cjs
+++ b/monorepo/eslint-config-sane/library.cjs
@@ -16,7 +16,7 @@ module.exports = {
       typescript: true,
     },
   },
-  ignorePatterns: ["node_modules/", "dist/", "lib/"],
+  ignorePatterns: ["node_modules/", "build/"],
   rules: {
     "@typescript-eslint/consistent-type-imports": "error",
 

--- a/monorepo/mytsup/tsup.mjs
+++ b/monorepo/mytsup/tsup.mjs
@@ -7,13 +7,17 @@ export default async (options) => {
   return {
     entry: ["src/index.ts", "src/public/*.ts"],
     format: ["cjs", "esm"],
+    outDir: "build/js",
     clean: true,
+    silent: true,
     sourcemap: true,
     splitting: true,
     minify: !options.watch,
+    onSuccess: () => {
+      console.log("👍");
+    },
     treeshake: true,
     target: "es2022",
-    onSuccess: `tsc-absolute ${options.watch ? "--declarationMap" : ""}`,
     esbuildPlugins: [
       babel({
         config: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "turbo run build",
     "check-mrl": "mrl check --verbose",
     "ci:publish": "pnpm run prePublish && pnpm exec changeset publish",
-    "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot",
+    "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot --tag=next",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "prePublish": "turbo build && turbo lint",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "ci:publish": "pnpm run prePublish && pnpm exec changeset publish",
     "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot --tag=next",
     "dev": "turbo run dev",
+    "dev:typecheck": "tsc --build --watch --preserveWatchOutput packages/* examples/basic/*",
     "lint": "turbo run lint",
     "prePublish": "turbo build && turbo lint",
-    "typecheckAll": "tsc --build packages/* examples/basic/*",
-    "dev:typecheck": "tsc --build --watch --preserveWatchOutput packages/* examples/basic/*"
+    "typecheckAll": "tsc --build packages/* examples/basic/*"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "check-mrl": "mrl check --verbose",
     "ci:publish": "pnpm run prePublish && pnpm exec changeset publish",
     "ci:publishSnapshot": "pnpm run prePublish && pnpm exec changeset version --snapshot && pnpm exec changeset publish --no-git-tag --snapshot",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "prePublish": "turbo build && turbo lint"
+    "prePublish": "turbo build && turbo lint",
+    "typecheckAll": "tsc --build packages/* examples/basic/*",
+    "dev:typecheck": "tsc --build --watch --preserveWatchOutput packages/* examples/basic/*"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,23 +6,24 @@
   "license": "Apache-2.0",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./build/types/index.d.ts",
+      "import": "./build/js/index.mjs",
+      "require": "./build/js/index.js"
     },
     "./*": {
-      "types": "./src/public/*.ts",
-      "import": "./dist/public/*.mjs",
-      "require": "./dist/public/*.js"
+      "types": "./build/types/public/*.d.ts",
+      "import": "./build/js/public/*.mjs",
+      "require": "./build/js/public/*.js"
     }
   },
   "scripts": {
-    "build": "tsup",
-    "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
-    "dev": "tsup --watch",
+    "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
+    "dev:transpile": "tsup --watch",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",
     "prettier": "prettier .",
-    "typecheck": "tsc-absolute"
+    "transpile": "tsup",
+    "transpileWatch": "tsup --watch",
+    "typecheck": "tsc-absolute --build"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",
@@ -42,5 +43,11 @@
     "#client/converters": "./src/client/internal/conversions/index.ts",
     "#client/query": "./src/client/query/index.ts"
   },
-  "keywords": []
+  "keywords": [],
+  "files": [
+    "dist",
+    "types",
+    "CHANGELOG.md",
+    "package.json"
+  ]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "tsconfig/base",
-  "compilerOptions": { "rootDir": "src", "outDir": "lib" },
-  "include": ["./src/**/*", ".eslintrc.cjs"]
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/types",
+    "composite": true
+  },
+  "include": [
+    "./src/**/*",
+    ".eslintrc.cjs"
+  ],
+  "references": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,18 +81,9 @@ importers:
       '@types/node':
         specifier: ^18.0.0
         version: 18.17.15
-      eslint-config-sane:
-        specifier: workspace:*
-        version: link:../../../monorepo/eslint-config-sane
-      mytsup:
-        specifier: workspace:*
-        version: link:../../../monorepo/mytsup
       ts-expect:
         specifier: ^1.3.0
         version: 1.3.0
-      tsconfig:
-        specifier: workspace:*
-        version: link:../../../monorepo/tsconfig
 
   examples/basic/sdk:
     dependencies:
@@ -100,15 +91,6 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/api
     devDependencies:
-      eslint-config-sane:
-        specifier: workspace:*
-        version: link:../../../monorepo/eslint-config-sane
-      mytsup:
-        specifier: workspace:*
-        version: link:../../../monorepo/mytsup
-      tsconfig:
-        specifier: workspace:*
-        version: link:../../../monorepo/tsconfig
       typescript:
         specifier: ^5.2.2
         version: 5.2.2

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,16 @@
   "pipeline": {
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "dependsOn": ["//#dev:typecheck", "dev:transpile"]
+    },
+
+    "dev:transpile": {
+      "cache": false
+    },
+
+    "//#dev:typecheck": {
+      "cache": false
     },
 
     "lint": {
@@ -26,25 +35,51 @@
       "inputs": ["dprint.json"]
     },
 
-    "clean": {},
+    "clean": {
+      "cache": false
+    },
 
     "typecheck": {
       "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig.json"],
-      "outputs": [],
+      "outputs": ["types/**/*.d.ts", "types/**/*.d.ts.map"],
       "dependsOn": ["mytsup#typecheck", "^typecheck"]
     },
+
     "mytsup#typecheck": {
       "inputs": ["tsup.mjs"]
     },
+
     "tsconfig#typecheck": {
       "inputs": ["tsconfig.base.json"]
     },
 
     "build": {
-      "dependsOn": ["mytsup#typecheck", "tsconfig#typecheck", "^build"],
+      "dependsOn": ["transpile", "typecheck"]
+    },
+
+    "transpile": {
+      "dependsOn": ["mytsup#typecheck", "tsconfig#typecheck"],
       "inputs": ["src/**", "tsup.config.js", "tsconfig.json"],
       "outputs": ["dist/**", "lib/**"]
+    },
+
+    "//#check-mrl": {
+      "inputs": [
+        "package.json",
+        "packages/*/package.json",
+        "packages/*/tsconfig.json",
+        "examples/*/*/package.json",
+        "examples/*/*/tsconfig.json",
+        "monorepo/*/*/package.json",
+        "monorepo/*/*/tsconfig.json",
+        "templates/*"
+      ]
+    },
+
+    "check": {
+      "dependsOn": ["//#check-mrl", "lint", "build"]
     }
   },
+
   "globalDependencies": ["config/tsconfig.base.json"]
 }


### PR DESCRIPTION
* `turbo dev` provides better output and is more efficient for type checking
* (hopefully) snapshots are now published with the correct version and the npm tag `next`