### PR TITLE
Implement type tests for existing code

### DIFF
--- a/examples/basic/cli/src/examples/fetchAggregationForEmployees.ts
+++ b/examples/basic/cli/src/examples/fetchAggregationForEmployees.ts
@@ -16,6 +16,7 @@
 
 import type { Client } from "@osdk/api";
 import invariant from "tiny-invariant";
+import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
 import type { OntologyType } from "../OntologyType";
 
@@ -50,7 +51,7 @@ fetchAggregationForEmployees()
   }
 }
   */
-  // Compile Time Verification
+  // Compile Time Verification of rough shape
   expectType<{
     employeeNumber: {
       max: number | undefined;
@@ -64,6 +65,13 @@ fetchAggregationForEmployees()
       approximateDistinct: number;
     };
   }>(result);
+
+  // adUsername shouldn't be present
+  expectType<
+    TypeOf<{
+      adUsername: any;
+    }, typeof result>
+  >(false);
 
   // Runtime Verification
   invariant(

--- a/examples/basic/cli/src/examples/fetchAggregationForEmployeesGrouped.ts
+++ b/examples/basic/cli/src/examples/fetchAggregationForEmployeesGrouped.ts
@@ -16,6 +16,8 @@
 
 import type { Client } from "@osdk/api";
 import invariant from "tiny-invariant";
+import type { TypeOf } from "ts-expect";
+import { expectType } from "ts-expect";
 import type { OntologyType } from "../OntologyType";
 
 export async function fetchAggregationForEmployeesGrouped(
@@ -76,6 +78,32 @@ fetchAggregationForEmployeesGrouped()
   }
   */
 
+  // Compile time type verification
+  expectType<
+    TypeOf<
+      Array<{
+        group: {
+          locationType: string | undefined;
+        };
+        values: {
+          "employeeNumber": {
+            max: number | undefined;
+            avg: number | undefined;
+            min: number | undefined;
+          };
+          locationCity: {
+            approximateDistinct: number;
+          };
+          locationName: {
+            approximateDistinct: number;
+          };
+        };
+      }>,
+      typeof result
+    >
+  >(true);
+
+  // Runtime checks
   invariant(Array.isArray(result), "groups means we should get an array");
   invariant(Object.keys(result).length >= 1, "there should be one group");
   invariant(

--- a/examples/basic/cli/src/examples/fetchAggregationForEmployeesGroupedThin.ts
+++ b/examples/basic/cli/src/examples/fetchAggregationForEmployeesGroupedThin.ts
@@ -17,6 +17,8 @@
 import type { ThinClient } from "@osdk/api";
 import { aggregateOrThrow } from "@osdk/api/objects";
 import invariant from "tiny-invariant";
+import type { TypeOf } from "ts-expect";
+import { expectType } from "ts-expect";
 import type { OntologyType } from "../OntologyType";
 
 export async function fetchAggregationForEmployeesGroupedThin(
@@ -55,7 +57,30 @@ export async function fetchAggregationForEmployeesGroupedThin(
   console.log(JSON.stringify(result, undefined, 2));
   console.log();
 
-  result; //
+  expectType<
+    TypeOf<
+      Array<{
+        group: {
+          locationType: string | undefined;
+        };
+        values: {
+          "employeeNumber": {
+            max: number | undefined;
+            avg: number | undefined;
+            min: number | undefined;
+          };
+          locationCity: {
+            approximateDistinct: number;
+          };
+          locationName: {
+            approximateDistinct: number;
+          };
+        };
+      }>,
+      typeof result
+    >
+  >(true);
+
   result[0].values.employeeNumber;
   invariant(Array.isArray(result), "groups means we should get an array");
   invariant(Object.keys(result).length >= 1, "there should be one group");

--- a/examples/basic/cli/src/examples/fetchEmployeeLead.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeeLead.ts
@@ -15,6 +15,8 @@
  */
 
 import type { Client } from "@osdk/api";
+import type { TypeOf } from "ts-expect";
+import { expectType } from "ts-expect";
 import type { OntologyType } from "../OntologyType";
 
 export async function fetchEmployeeLead(
@@ -39,6 +41,28 @@ export async function fetchEmployeeLead(
   //   .fetchPageOrThrow({
   //     select: ["adUsername", "businessTitle", "employeeNumber"],
   //   });
+
+  // Check rough shape is correct.
+  expectType<
+    {
+      nextPageToken: string | undefined;
+      data: {
+        adUsername: string;
+        businessTitle: string | undefined;
+        employeeNumber: number | undefined;
+      }[];
+    }
+  >(result);
+
+  // check down select worked
+  expectType<
+    TypeOf<{
+      data: {
+        jobProfile: any; // should be omitted
+      }[];
+    }, typeof result>
+  >(false);
+
   console.log(`fetchEmployeePageByAdUsername('${adUsername}')`);
   console.table(
     result.data.map(({ adUsername, businessTitle, employeeNumber }) => ({

--- a/examples/basic/cli/src/examples/fetchEmployeePage.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeePage.ts
@@ -22,6 +22,17 @@ export async function fetchEmployeePage(client: Client<OntologyType>) {
   const result = await client.objectSet("Employee").fetchPageOrThrow();
   expectType<string | undefined>(result.data[0].businessTitle);
 
+  // Rough shape is correct
+  expectType<
+    {
+      data: {
+        adUsername: string;
+        businessTitle: string | undefined;
+        employeeNumber: number | undefined;
+      }[];
+    }
+  >(result);
+
   console.log("fetchEmployeePage(): ");
   console.table(
     result.data.map(({ adUsername, businessTitle, employeeNumber }) => ({

--- a/examples/basic/cli/src/examples/fetchEmployeePageThin.ts
+++ b/examples/basic/cli/src/examples/fetchEmployeePageThin.ts
@@ -30,11 +30,11 @@ export async function fetchEmployeePageThin(
 
   expectType<string>(result.data[0].adUsername);
 
-  // locationCity was not selected!
+  // locationCity was not selected. Should not be present
   expectType<
     TypeOf<
       {
-        locationCity: string | undefined;
+        locationCity: any;
       },
       (typeof result.data)[0]
     >

--- a/examples/basic/cli/src/index.ts
+++ b/examples/basic/cli/src/index.ts
@@ -25,6 +25,7 @@ import { fetchEmployeePageByAdUsername } from "./examples/fetchEmployeePageByAdU
 import { fetchEmployeePageByAdUsernameAndLimit } from "./examples/fetchEmployeePageByAdUsernameAndLimit";
 import { fetchEmployeePageThin } from "./examples/fetchEmployeePageThin";
 import type { OntologyType } from "./OntologyType";
+import { typeChecks } from "./typeChecks";
 
 declare global {
   namespace NodeJS {
@@ -58,6 +59,8 @@ async function runTests() {
 
     await fetchAggregationForEmployeesGroupedThin(thinClient);
     await fetchEmployeeLead(client, "bob");
+
+    await typeChecks(client);
   } catch (e) {
     console.error("Caught an error we did not expect", typeof e);
     console.error(e);

--- a/examples/basic/cli/src/typeChecks.ts
+++ b/examples/basic/cli/src/typeChecks.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client } from "@osdk/api";
+import type { TypeOf } from "ts-expect";
+import { expectType } from "ts-expect";
+import type { OntologyType } from "./OntologyType";
+
+export function typeChecks(client: Client<OntologyType>) {
+  // client.objectSet("Employee") is the same as client.objects.Employee
+  {
+    const objectSet = client.objectSet("Employee");
+    expectType<TypeOf<typeof objectSet, typeof client["objects"]["Employee"]>>(
+      true,
+    );
+  }
+
+  // single link pivot types are correct
+  {
+    const objectSet = client.objectSet("Employee").pivotTo("lead");
+    expectType<TypeOf<typeof objectSet, typeof client["objects"]["Employee"]>>(
+      true,
+    );
+  }
+
+  // multi link pivot types are correct
+  {
+    const objectSet = client.objectSet("Employee").pivotTo("peeps");
+    expectType<TypeOf<typeof objectSet, typeof client["objects"]["Employee"]>>(
+      true,
+    );
+  }
+}

--- a/packages/api/src/client/object/aggregateOrThrow.test.ts
+++ b/packages/api/src/client/object/aggregateOrThrow.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { OntologyDefinition } from "#ontology";
+import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
 import { createThinClient } from "../createThinClient";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts";
@@ -66,7 +67,14 @@ export async function test1() {
   expectType<number | undefined>(notGrouped.priority.avg);
   expectType<number | undefined>(notGrouped.id.max);
   expectType<number | undefined>(notGrouped.id.avg);
-  expectType<never>(notGrouped.other);
+  expectType<
+    TypeOf<
+      {
+        other: any;
+      },
+      typeof notGrouped
+    >
+  >(false); // subselect should hide unused keys
 
   const grouped = await aggregateOrThrow(thinClient, "Todo", {
     select: {

--- a/packages/api/src/client/query/aggregations/AggregationResultsWithoutGroups.ts
+++ b/packages/api/src/client/query/aggregations/AggregationResultsWithoutGroups.ts
@@ -24,12 +24,16 @@ import type {
 import type { StringArrayToUnion } from "#util";
 import type { AggregationClause } from "./AggregationsClause";
 
+type SubselectKeys<AC extends AggregationClause<any, any>, P extends keyof AC> =
+  AC[P] extends readonly string[] | string ? P : never;
+
 export type AggregationResultsWithoutGroups<
   O extends OntologyDefinition<any>,
   K extends ObjectTypesFrom<O>,
   AC extends AggregationClause<O, K>,
 > = {
-  [P in PropertyKeysFrom<O, K>]: AC[P] extends readonly string[] | string ? {
+  [P in PropertyKeysFrom<O, K> as SubselectKeys<AC, P>]: AC[P] extends
+    readonly string[] | string ? {
       [Z in StringArrayToUnion<AC[P]>]: Z extends "approximateDistinct" ? number
         : OsdkObjectPropertyType<PropertyDefinitionFrom<O, K, P>>;
     }


### PR DESCRIPTION
Provides some sanity that we don't break the derived type APIs when we make changes.

We will need to keep adding to this as we discover new issues and implement new features.

**Bonus:** Doing this helped expose + fix properties showing up in intellisense as `adUsername: never` for aggregations instead of just omitting it. This PR also fixes that.