### PR TITLE
Removing subpath imports as they don't play nice with TypeScript

### DIFF
--- a/.changeset/honest-shoes-exercise.md
+++ b/.changeset/honest-shoes-exercise.md
@@ -1,0 +1,9 @@
+---
+"@osdk/legacy-client": patch
+"@osdk/generator": patch
+"@osdk/gateway": patch
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Removing subpath imports since TS does not resolve them when creating `.d.ts` files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,5 @@
   },
   "[json]": {
     "editor.defaultFormatter": "dprint.dprint"
-  },
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "always"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   },
   "[json]": {
     "editor.defaultFormatter": "dprint.dprint"
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "always"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,13 +39,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "imports": {
-    "#net": "./src/client/internal/net/index.ts",
-    "#util": "./src/util/index.ts",
-    "#ontology": "./src/ontology/index.ts",
-    "#client/converters": "./src/client/internal/conversions/index.ts",
-    "#client/query": "./src/client/query/index.ts"
-  },
   "keywords": [],
   "files": [
     "build/types",

--- a/packages/api/src/client/Client.ts
+++ b/packages/api/src/client/Client.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
+import type { ObjectTypesFrom, OntologyDefinition } from "../ontology";
 import type { ObjectSet, ObjectSetOptions } from "./objectSet/ObjectSet";
 import type { ObjectSetCreator } from "./ObjectSetCreator";
 

--- a/packages/api/src/client/ObjectSetCreator.ts
+++ b/packages/api/src/client/ObjectSetCreator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
+import type { ObjectTypesFrom, OntologyDefinition } from "../ontology";
 import type { Client } from "./Client";
 import type { ObjectSet } from "./objectSet/ObjectSet";
 

--- a/packages/api/src/client/PageResult.ts
+++ b/packages/api/src/client/PageResult.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { OsdkObject } from "#ontology";
+import type { OsdkObject } from "../ontology";
 
 export interface PageResult<T extends OsdkObject<any>> {
   data: T[];

--- a/packages/api/src/client/ThinClient.ts
+++ b/packages/api/src/client/ThinClient.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type * as ontology from "#ontology";
-import type { FetchAsJsonFn } from "#util";
+import type * as ontology from "../ontology";
+import type { FetchAsJsonFn } from "../util";
 
 export interface ThinClient<O extends ontology.OntologyDefinition<any>> {
   ontology: O;

--- a/packages/api/src/client/createClient.ts
+++ b/packages/api/src/client/createClient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { OntologyDefinition } from "#ontology";
+import type { OntologyDefinition } from "../ontology";
 import type { Client } from "./Client";
 import { createThinClient } from "./createThinClient";
 import { createObjectSet } from "./objectSet/createObjectSet";

--- a/packages/api/src/client/createThinClient.ts
+++ b/packages/api/src/client/createThinClient.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type { OntologyDefinition } from "#ontology";
+import type { OntologyDefinition } from "../ontology";
 import {
   createFetchAsJson,
   createFetchHeaderMutator,
   createFetchOrThrow,
   createRetryingFetch,
-} from "#util";
+} from "../util";
 import type { ThinClient } from "./ThinClient";
 
 /**

--- a/packages/api/src/client/internal/conversions/legacyToModernSingleAggregationResult.ts
+++ b/packages/api/src/client/internal/conversions/legacyToModernSingleAggregationResult.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import invariant from "tiny-invariant";
+import type { ArrayElement } from "../../../util";
 import type {
   AggregationClause,
   AggregationResultsWithoutGroups,
-} from "#client/query";
-import type { Wire } from "#net";
-import type { ArrayElement } from "#util";
-import invariant from "tiny-invariant";
+} from "../../query";
+import type { Wire } from "../net";
 
 export function legacyToModernSingleAggregationResult<
   AC extends AggregationClause<any, any>,

--- a/packages/api/src/client/internal/conversions/modernToLegacyAggregationClause.ts
+++ b/packages/api/src/client/internal/conversions/modernToLegacyAggregationClause.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { AggregationClause } from "#client/query";
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
 import type { Aggregation } from "@osdk/gateway/types";
+import type { ObjectTypesFrom, OntologyDefinition } from "../../../ontology";
+import type { AggregationClause } from "../../query";
 
 export function modernToLegacyAggregationClause<
   T extends OntologyDefinition<any>,

--- a/packages/api/src/client/internal/conversions/modernToLegacyGroupByClause.ts
+++ b/packages/api/src/client/internal/conversions/modernToLegacyGroupByClause.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { AllGroupByValues, GroupByClause } from "#client/query";
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
 import type { AggregationGroupByV2 } from "@osdk/gateway/types";
+import type { ObjectTypesFrom, OntologyDefinition } from "../../../ontology";
+import type { AllGroupByValues, GroupByClause } from "../../query";
 
 export function modernToLegacyGroupByClause<
   O extends OntologyDefinition<any>,

--- a/packages/api/src/client/internal/conversions/modernToLegacyWhereClause.ts
+++ b/packages/api/src/client/internal/conversions/modernToLegacyWhereClause.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
+import invariant from "tiny-invariant";
+import type { ObjectDefinition } from "../../../ontology";
 import type {
   AndWhereClause,
   NotWhereClause,
   OrWhereClause,
   PossibleWhereClauseFilters,
   WhereClause,
-} from "#client/query";
-import type { Wire } from "#net";
-import type { ObjectDefinition } from "#ontology";
-import invariant from "tiny-invariant";
+} from "../../query";
+import type { Wire } from "../net";
 
 export function modernToLegacyWhereClause<T extends ObjectDefinition<any, any>>(
   whereClause: WhereClause<T>,

--- a/packages/api/src/client/object/aggregateOrThrow.test.ts
+++ b/packages/api/src/client/object/aggregateOrThrow.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { OntologyDefinition } from "#ontology";
 import type { AggregateObjectSetResponseV2 } from "@osdk/gateway/types";
 import type { TypeOf } from "ts-expect";
 import { expectType } from "ts-expect";
 import { describe, expect, it, type Mock, vi } from "vitest";
+import type { OntologyDefinition } from "../../ontology";
 import { createThinClient } from "../createThinClient";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts";
 import { aggregateOrThrow } from "./aggregateOrThrow";

--- a/packages/api/src/client/object/aggregateOrThrow.ts
+++ b/packages/api/src/client/object/aggregateOrThrow.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
+import { aggregateObjectsV2 } from "@osdk/gateway/requests";
+import type { AggregateObjectsRequestV2 } from "@osdk/gateway/types";
+import invariant from "tiny-invariant";
+import type { ObjectTypesFrom, OntologyDefinition } from "../../ontology";
 import {
   legacyToModernSingleAggregationResult,
   modernToLegacyAggregationClause,
   modernToLegacyGroupByClause,
   modernToLegacyWhereClause,
-} from "#client/converters";
+} from "../internal/conversions";
+import { createOpenApiRequest } from "../internal/net";
 import type {
   AggregationResultsWithGroups,
   AggregationsResults,
-} from "#client/query";
-import { createOpenApiRequest } from "#net";
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
-import { aggregateObjectsV2 } from "@osdk/gateway/requests";
-import type { AggregateObjectsRequestV2 } from "@osdk/gateway/types";
-import invariant from "tiny-invariant";
+} from "../query";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts";
 import type { ThinClient } from "../ThinClient";
 

--- a/packages/api/src/client/object/fetchPageOrThrow.ts
+++ b/packages/api/src/client/object/fetchPageOrThrow.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { createOpenApiRequest } from "#net";
-import type { Wire } from "#net";
+import { loadObjectSetV2 } from "@osdk/gateway/requests";
+import type { LoadObjectSetRequestV2 } from "@osdk/gateway/types";
 import type {
   ObjectTypesFrom,
   OntologyDefinition,
   OsdkObjectFrom,
   PropertyKeysFrom,
-} from "#ontology";
-import type { NOOP } from "#util";
-import { loadObjectSetV2 } from "@osdk/gateway/requests";
-import type { LoadObjectSetRequestV2 } from "@osdk/gateway/types";
+} from "../../ontology";
+import type { NOOP } from "../../util";
+import type { Wire } from "../internal/net";
+import { createOpenApiRequest } from "../internal/net";
 import type { PageResult } from "../PageResult";
 import type { ThinClient } from "../ThinClient";
 

--- a/packages/api/src/client/objectSet/LinkTypesFrom.ts
+++ b/packages/api/src/client/objectSet/LinkTypesFrom.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
+import type { ObjectTypesFrom, OntologyDefinition } from "../../ontology";
 
 export type LinkTypesFrom<
   O extends OntologyDefinition<string>,

--- a/packages/api/src/client/objectSet/ObjectSet.ts
+++ b/packages/api/src/client/objectSet/ObjectSet.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import type { AggregationsResults, WhereClause } from "#client/query";
 import type {
   ObjectInfoFrom,
   ObjectTypesFrom,
   OntologyDefinition,
   OsdkObjectFrom,
   PropertyKeysFrom,
-} from "#ontology";
+} from "../../ontology";
 import type { FetchPageOrThrowArgs } from "../object/fetchPageOrThrow";
 import type { PageResult } from "../PageResult";
+import type { AggregationsResults, WhereClause } from "../query";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts";
 import type { ResultOrError } from "../ResultOrError";
 import type { LinkTypesFrom } from "./LinkTypesFrom";

--- a/packages/api/src/client/objectSet/createObjectSet.ts
+++ b/packages/api/src/client/objectSet/createObjectSet.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { modernToLegacyWhereClause } from "#client/converters";
-import type {
-  AggregationClause,
-  AggregationsResults,
-  GroupByClause,
-  WhereClause,
-} from "#client/query";
-import type { Wire } from "#net";
 import type {
   ObjectInfoFrom,
   ObjectTypesFrom,
   OntologyDefinition,
   PropertyKeysFrom,
-} from "#ontology";
+} from "../../ontology";
+import { modernToLegacyWhereClause } from "../internal/conversions";
+import type { Wire } from "../internal/net";
 import { aggregateOrThrow, fetchPageOrThrow } from "../object";
 import type { FetchPageOrThrowArgs } from "../object/fetchPageOrThrow";
+import type {
+  AggregationClause,
+  AggregationsResults,
+  GroupByClause,
+  WhereClause,
+} from "../query";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts";
 import type { ThinClient } from "../ThinClient";
 import type { LinkTypesFrom } from "./LinkTypesFrom";

--- a/packages/api/src/client/query/WhereClause.ts
+++ b/packages/api/src/client/query/WhereClause.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectDefinition, PropertyDefinition } from "#ontology";
+import type { ObjectDefinition, PropertyDefinition } from "../../ontology";
 
 export type PossibleWhereClauseFilters =
   | "gt"

--- a/packages/api/src/client/query/aggregations/AggregatableKeys.ts
+++ b/packages/api/src/client/query/aggregations/AggregatableKeys.ts
@@ -19,7 +19,7 @@ import type {
   ObjectTypesFrom,
   OntologyDefinition,
   PropertyKeysFrom,
-} from "#ontology";
+} from "../../../ontology";
 
 type Q<
   O extends OntologyDefinition<any>,

--- a/packages/api/src/client/query/aggregations/AggregateOpts.ts
+++ b/packages/api/src/client/query/aggregations/AggregateOpts.ts
@@ -15,15 +15,15 @@
  */
 
 import type {
-  AggregationClause,
-  GroupByClause,
-  WhereClause,
-} from "#client/query";
-import type {
   ObjectInfoFrom,
   ObjectTypesFrom,
   OntologyDefinition,
-} from "#ontology";
+} from "../../../ontology";
+import type {
+  AggregationClause,
+  GroupByClause,
+  WhereClause,
+} from "../../query";
 
 export type AggregateOpts<
   T extends OntologyDefinition<any>,

--- a/packages/api/src/client/query/aggregations/AggregationResultsWithGroups.ts
+++ b/packages/api/src/client/query/aggregations/AggregationResultsWithGroups.ts
@@ -20,7 +20,7 @@ import type {
   OsdkObjectPropertyType,
   PropertyDefinitionFrom,
   PropertyKeysFrom,
-} from "#ontology";
+} from "../../../ontology";
 import type { AggregationResultsWithoutGroups } from "./AggregationResultsWithoutGroups";
 import type { AggregationClause } from "./AggregationsClause";
 import type { GroupByClause } from "./GroupByClause";

--- a/packages/api/src/client/query/aggregations/AggregationResultsWithoutGroups.ts
+++ b/packages/api/src/client/query/aggregations/AggregationResultsWithoutGroups.ts
@@ -20,8 +20,8 @@ import type {
   OsdkObjectPropertyType,
   PropertyDefinitionFrom,
   PropertyKeysFrom,
-} from "#ontology";
-import type { StringArrayToUnion } from "#util";
+} from "../../../ontology";
+import type { StringArrayToUnion } from "../../../util";
 import type { AggregationClause } from "./AggregationsClause";
 
 type SubselectKeys<AC extends AggregationClause<any, any>, P extends keyof AC> =

--- a/packages/api/src/client/query/aggregations/AggregationsClause.ts
+++ b/packages/api/src/client/query/aggregations/AggregationsClause.ts
@@ -18,7 +18,7 @@ import type {
   ObjectTypesFrom,
   OntologyDefinition,
   PropertyDefinitionsFrom,
-} from "#ontology";
+} from "../../../ontology";
 import type { AggregatableKeys } from "./AggregatableKeys";
 
 type StringAggregateOption = "approximateDistinct";

--- a/packages/api/src/client/query/aggregations/AggregationsResults.ts
+++ b/packages/api/src/client/query/aggregations/AggregationsResults.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectTypesFrom, OntologyDefinition } from "#ontology";
+import type { ObjectTypesFrom, OntologyDefinition } from "../../../ontology";
 import type { AggregateOpts } from "./AggregateOpts";
 import type { AggregationResultsWithGroups } from "./AggregationResultsWithGroups";
 import type { AggregationResultsWithoutGroups } from "./AggregationResultsWithoutGroups";

--- a/packages/api/src/client/query/aggregations/GroupByClause.ts
+++ b/packages/api/src/client/query/aggregations/GroupByClause.ts
@@ -18,7 +18,7 @@ import type {
   ObjectTypesFrom,
   OntologyDefinition,
   PropertyDefinitionFrom,
-} from "#ontology";
+} from "../../../ontology";
 import type { AggregatableKeys } from "./AggregatableKeys";
 import type { GroupByMapper } from "./GroupByMapper";
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-export type { WhereClause } from "#client/query";
-export type { OsdkObject } from "#ontology";
 export { createClient, createThinClient, isOk } from "./client";
 export type { Client, ObjectSet, ResultOrError, ThinClient } from "./client";
+export type { WhereClause } from "./client/query";
+export type { OsdkObject } from "./ontology";
 
 // FIXME: Shoudl this be Objects or Object?
 export * as Objects from "./client/object";

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,13 +37,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "imports": {
-    "#net": "./src/client/internal/net/index.ts",
-    "#util": "./src/util/index.ts",
-    "#ontology": "./src/ontology/index.ts",
-    "#client/converters": "./src/client/internal/conversions/index.ts",
-    "#client/query": "./src/client/query/index.ts"
-  },
   "keywords": [],
   "files": [
     "build/types",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -36,13 +36,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "imports": {
-    "#net": "./src/client/internal/net/index.ts",
-    "#util": "./src/util/index.ts",
-    "#ontology": "./src/ontology/index.ts",
-    "#client/converters": "./src/client/internal/conversions/index.ts",
-    "#client/query": "./src/client/query/index.ts"
-  },
   "keywords": [],
   "files": [
     "build/types",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -39,13 +39,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "imports": {
-    "#net": "./src/client/internal/net/index.ts",
-    "#util": "./src/util/index.ts",
-    "#ontology": "./src/ontology/index.ts",
-    "#client/converters": "./src/client/internal/conversions/index.ts",
-    "#client/query": "./src/client/query/index.ts"
-  },
   "keywords": [],
   "files": [
     "build/types",

--- a/packages/legacy-client/package.json
+++ b/packages/legacy-client/package.json
@@ -36,13 +36,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "imports": {
-    "#net": "./src/client/internal/net/index.ts",
-    "#util": "./src/util/index.ts",
-    "#ontology": "./src/ontology/index.ts",
-    "#client/converters": "./src/client/internal/conversions/index.ts",
-    "#client/query": "./src/client/query/index.ts"
-  },
   "keywords": [],
   "files": [
     "build/types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      typescript-transform-paths:
+        specifier: ^3.4.6
+        version: 3.4.6(typescript@5.2.2)
 
   packages/client:
     dependencies:
@@ -4657,6 +4660,15 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
+    dev: true
+
+  /typescript-transform-paths@3.4.6(typescript@5.2.2):
+    resolution: {integrity: sha512-qdgpCk9oRHkIBhznxaHAapCFapJt5e4FbFik7Y4qdqtp6VyC3smAIPoDEIkjZ2eiF7x5+QxUPYNwJAtw0thsTw==}
+    peerDependencies:
+      typescript: '>=3.6.5'
+    dependencies:
+      minimatch: 3.1.2
+      typescript: 5.2.2
     dev: true
 
   /typescript@5.2.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,6 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
-      typescript-transform-paths:
-        specifier: ^3.4.6
-        version: 3.4.6(typescript@5.2.2)
 
   packages/client:
     dependencies:
@@ -4660,15 +4657,6 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
-    dev: true
-
-  /typescript-transform-paths@3.4.6(typescript@5.2.2):
-    resolution: {integrity: sha512-qdgpCk9oRHkIBhznxaHAapCFapJt5e4FbFik7Y4qdqtp6VyC3smAIPoDEIkjZ2eiF7x5+QxUPYNwJAtw0thsTw==}
-    peerDependencies:
-      typescript: '>=3.6.5'
-    dependencies:
-      minimatch: 3.1.2
-      typescript: 5.2.2
     dev: true
 
   /typescript@5.2.2:


### PR DESCRIPTION
TypeScript doesn't support subpath aliases very well in compiled `.d.ts` so relying on the outputted types doesn't work.
https://github.com/microsoft/TypeScript/issues/44848

Alternatively, we can explore something like this solution and re-writing the paths with a plugin: https://github.com/microsoft/TypeScript/issues/44848#issuecomment-1370175916