### PR TITLE
Adding stubs for FoundryClient for backcompat

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   },
   "[json]": {
     "editor.defaultFormatter": "dprint.dprint"
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
   }
 }

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.test.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.test.ts
@@ -38,7 +38,10 @@ describe("generator", () => {
       helper.getFiles()[`${BASE_PATH}/index.ts`],
     ).toMatchInlineSnapshot(`
       "// Path: /foo/index.ts
+      import { Auth, FoundryClientOptions, BaseFoundryClient } from '@osdk/legacy-client';
       export const ontologyRid = 'ridHere';
+      export * from '@osdk/legacy-client';
+      export { FoundryClient } from './FoundryClient';
       "
     `);
 
@@ -49,6 +52,9 @@ describe("generator", () => {
       );
     }
 
-    expect(diagnostics).toHaveLength(0);
+    // TODO: Certain errors are expected since we can't resolve the static code, but we should fix them.
+    const errors = diagnostics.filter((q) => q.code !== 2792);
+
+    expect(errors).toHaveLength(0);
   });
 });

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -18,6 +18,8 @@ import * as path from "node:path";
 import type { MinimalFs } from "../MinimalFs";
 import { formatTs } from "../util/test/formatTs";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
+import { generateFoundryClient } from "./generateFoundryClient";
+import { generateMetadata } from "./generateMetadata";
 
 export async function generateClientSdkVersionOneDotOne(
   ontology: WireOntologyDefinition,
@@ -99,12 +101,16 @@ export async function generateClientSdkVersionOneDotOne(
       } from "./internal/@foundry/oauth-client/dist";
    */
 
+  await generateFoundryClient(fs, outDir);
+  await generateMetadata(ontology, fs, outDir);
+
   await fs.writeFile(
     path.join(outDir, "index.ts"),
     await formatTs(`// Path: ${path.join(outDir, "index.ts")}
+    import { Auth, FoundryClientOptions, BaseFoundryClient } from "@osdk/legacy-client";
     export const ontologyRid = "${rid}";
-
     export * from "@osdk/legacy-client";
+    export { FoundryClient } from "./FoundryClient";
     `),
   );
 }

--- a/packages/generator/src/v1.1/generateFoundryClient.test.ts
+++ b/packages/generator/src/v1.1/generateFoundryClient.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
+import { generateFoundryClient } from "./generateFoundryClient";
+
+describe("generateFoundryClient", () => {
+  it("generates foundry client", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+
+    await generateFoundryClient(
+      helper.minimalFiles,
+      BASE_PATH,
+    );
+
+    expect(helper.minimalFiles.writeFile).toBeCalled();
+
+    expect(
+      helper.getFiles()[`${BASE_PATH}/FoundryClient.ts`],
+    ).toMatchInlineSnapshot(`
+      "// Path: /foo/FoundryClient
+      import { OntologyDefinition } from './OntologyDefinition';
+      export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<OntologyDefinition> {
+        constructor(options: FoundryClientOptions<TAuth>) {
+          super();
+        }
+      }
+      "
+    `);
+  });
+});

--- a/packages/generator/src/v1.1/generateFoundryClient.test.ts
+++ b/packages/generator/src/v1.1/generateFoundryClient.test.ts
@@ -35,9 +35,9 @@ describe("generateFoundryClient", () => {
     ).toMatchInlineSnapshot(`
       "// Path: /foo/FoundryClient
       import { OntologyDefinition } from './OntologyDefinition';
-      export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<OntologyDefinition> {
+      export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<OntologyDefinition, TAuth> {
         constructor(options: FoundryClientOptions<TAuth>) {
-          super();
+          super(options);
         }
       }
       "

--- a/packages/generator/src/v1.1/generateFoundryClient.ts
+++ b/packages/generator/src/v1.1/generateFoundryClient.ts
@@ -28,7 +28,7 @@ export async function generateFoundryClient(
     import { OntologyDefinition } from "./OntologyDefinition";
     export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<OntologyDefinition, TAuth> {
         constructor(options: FoundryClientOptions<TAuth>) {
-          super();
+          super(options);
         }
     }`),
   );

--- a/packages/generator/src/v1.1/generateFoundryClient.ts
+++ b/packages/generator/src/v1.1/generateFoundryClient.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import type { MinimalFs } from "../MinimalFs";
+import { formatTs } from "../util/test/formatTs";
+
+export async function generateFoundryClient(
+  fs: MinimalFs,
+  outDir: string,
+) {
+  await fs.writeFile(
+    path.join(outDir, "FoundryClient.ts"),
+    await formatTs(`// Path: ${path.join(outDir, "FoundryClient")}
+    import { OntologyDefinition } from "./OntologyDefinition";
+    export class FoundryClient<TAuth extends Auth = Auth> extends BaseFoundryClient<OntologyDefinition, TAuth> {
+        constructor(options: FoundryClientOptions<TAuth>) {
+          super();
+        }
+    }`),
+  );
+}

--- a/packages/generator/src/v1.1/generateMetadata.test.ts
+++ b/packages/generator/src/v1.1/generateMetadata.test.ts
@@ -14,41 +14,38 @@
  * limitations under the License.
  */
 
-import { describe, expect, test } from "vitest";
-import { compileThis } from "../util/test/compileThis";
+import { describe, expect, it } from "vitest";
 import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
 import { TodoWireOntology } from "../util/test/TodoWireOntology";
-import { generateClientSdkVersionTwoPointZero } from "./generateClientSdkVersionTwoPointZero";
+import { generateMetadata } from "./generateMetadata";
 
-describe("generator", () => {
-  test("should be able to generate a project", async () => {
+describe("generateMetadata", () => {
+  it("generates metadata", async () => {
     const helper = createMockMinimalFiles();
     const BASE_PATH = "/foo";
 
-    await generateClientSdkVersionTwoPointZero(
+    await generateMetadata(
       TodoWireOntology,
       helper.minimalFiles,
       BASE_PATH,
     );
 
-    const files = helper.getFiles();
+    expect(helper.minimalFiles.writeFile).toBeCalled();
 
-    expect(files).toMatchObject({
-      [`${BASE_PATH}/index.ts`]: expect.anything(),
-      [`${BASE_PATH}/Ontology.ts`]: expect.anything(),
-      [`${BASE_PATH}/objects/Todo.ts`]: expect.anything(),
-    });
-
-    helper.dumpFilesToConsole();
-
-    const diagnostics = compileThis(helper.getFiles(), BASE_PATH);
-    for (const q of diagnostics) {
-      console.error(
-        `${q.file?.fileName}:${q.file?.getLineStarts()} ${q.messageText}`,
-      );
-    }
-
-    const errors = diagnostics.filter(q => q.code !== 2792);
-    expect(errors).toHaveLength(0);
+    expect(
+      helper.getFiles()[`${BASE_PATH}/OntologyDefinition.ts`],
+    ).toMatchInlineSnapshot(`
+      "// Path: /foo/OntologyDefinition
+      import type { OntologyDefinition as ApiOntologyDefinition } from '@osdk/legacy-client';
+      export const OntologyDefinition = {
+        metadata: {
+          ontologyRid: 'ridHere',
+          ontologyApiName: 'OntologyApiName',
+          userAgent: 'foundry-typescript-osdk/0.0.1',
+        },
+        objects: {},
+      } satisfies ApiOntologyDefinition<'Todo'>;
+      "
+    `);
   });
 });

--- a/packages/generator/src/v1.1/generateMetadata.ts
+++ b/packages/generator/src/v1.1/generateMetadata.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "node:path";
+import type { MinimalFs } from "../MinimalFs";
+import { formatTs } from "../util/test/formatTs";
+import type { WireOntologyDefinition } from "../WireOntologyDefinition";
+
+export async function generateMetadata(
+  ontology: WireOntologyDefinition,
+  fs: MinimalFs,
+  outDir: string,
+) {
+  await fs.writeFile(
+    path.join(outDir, "OntologyDefinition.ts"),
+    await formatTs(`// Path: ${path.join(outDir, "OntologyDefinition")}
+  import type { OntologyDefinition as ApiOntologyDefinition } from "@osdk/legacy-client";
+  export const OntologyDefinition = {
+    metadata: {
+        ontologyRid: "${ontology.rid}",
+        ontologyApiName: "${ontology.apiName}",
+        userAgent: "foundry-typescript-osdk/0.0.1",
+    },
+    objects: {
+    }
+  } satisfies ApiOntologyDefinition<${
+      Object.keys(ontology.objectTypes).map((o) =>
+        `"${ontology.objectTypes[o].apiName}"`
+      ).join(" | ")
+    }>;`),
+  );
+}

--- a/packages/legacy-client/src/client/foundryClient.ts
+++ b/packages/legacy-client/src/client/foundryClient.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyDefinition } from "../metadata";
+import type { Auth } from "../oauth-client";
+import { Ontology } from "./ontology";
+
+export class BaseFoundryClient<
+  O extends OntologyDefinition<any>,
+  TAuth extends Auth = Auth,
+> {
+  get ontology(): Ontology<O> {
+    return new Ontology<O>();
+  }
+
+  get auth(): TAuth {
+    throw new Error("not implemented");
+  }
+}

--- a/packages/legacy-client/src/client/foundryClientOptions.ts
+++ b/packages/legacy-client/src/client/foundryClientOptions.ts
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-import type { OntologyDefinition } from "../metadata";
 import type { Auth } from "../oauth-client";
-import type { FoundryClientOptions } from "./foundryClientOptions";
-import { Ontology } from "./ontology";
 
-export class BaseFoundryClient<
-  O extends OntologyDefinition<any>,
-  TAuth extends Auth = Auth,
-> {
-  constructor(private foundryClientOptions: FoundryClientOptions<TAuth>) {}
-
-  get ontology(): Ontology<O> {
-    return new Ontology<O>();
-  }
-
-  get auth(): TAuth {
-    throw new Error("not implemented");
-  }
+export interface FoundryClientOptions<TAuth extends Auth = Auth> {
+  url: string;
+  auth: TAuth;
+  /**
+   * The fetch function to use for making requests. By default, it uses the global `fetch` function with error handling,
+   * authentication, and automatic retries.
+   */
+  fetchFunction?: typeof globalThis.fetch;
 }

--- a/packages/legacy-client/src/client/index.ts
+++ b/packages/legacy-client/src/client/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./foundryClient";

--- a/packages/legacy-client/src/client/index.ts
+++ b/packages/legacy-client/src/client/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from "./foundryClient";
+export * from "./foundryClientOptions";

--- a/packages/legacy-client/src/client/ontology.test.ts
+++ b/packages/legacy-client/src/client/ontology.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from "vitest";
+import type { MockOntology } from "../util/test";
+import { Ontology } from "./ontology";
+describe("ontology", () => {
+  it("correct types", () => {
+    const ontology = new Ontology<typeof MockOntology>();
+    ontology.objects.test;
+  });
+});

--- a/packages/legacy-client/src/client/ontology.ts
+++ b/packages/legacy-client/src/client/ontology.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyDefinition } from "../metadata";
+
+export class Ontology<O extends OntologyDefinition<any>> {
+  get objects(): O["objects"] {
+    throw new Error("not implemented");
+  }
+
+  get actions(): never {
+    throw new Error("not implemented");
+  }
+
+  get queries(): never {
+    throw new Error("not implemented");
+  }
+
+  get attachments(): never {
+    throw new Error("not implemented");
+  }
+}

--- a/packages/legacy-client/src/index.ts
+++ b/packages/legacy-client/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { BaseFoundryClient, type FoundryClientOptions } from "./client";
 export {
   ConfidentialClientAuth,
   PublicClientAuth,

--- a/packages/legacy-client/src/metadata/OntologyDefinition.ts
+++ b/packages/legacy-client/src/metadata/OntologyDefinition.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { LocalDate } from "../ontology-runtime/baseTypes";
+
+export interface OntologyDefinition<K extends string> {
+  metadata: OntologyMetadata;
+  objects: {
+    [KK in K]: ObjectDefinition<KK, K>;
+  };
+}
+
+export interface OntologyMetadata {
+}
+
+export interface ObjectDefinition<N extends K, K extends string> {
+  apiName: N;
+  properties: Record<string, PropertyDefinition>;
+}
+
+export interface PropertyDefinition {
+  isPrimaryKey: boolean;
+  type: PropertyType;
+}
+
+interface PropertyType {
+  string: string;
+  datetime: LocalDate;
+  double: number;
+  boolean: boolean;
+}

--- a/packages/legacy-client/src/metadata/index.ts
+++ b/packages/legacy-client/src/metadata/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type { OntologyDefinition } from "./OntologyDefinition";

--- a/packages/legacy-client/src/util/test/index.ts
+++ b/packages/legacy-client/src/util/test/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./mockOntology";

--- a/packages/legacy-client/src/util/test/mockOntology.ts
+++ b/packages/legacy-client/src/util/test/mockOntology.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyDefinition } from "../../metadata";
+
+export const MockOntology = {
+  metadata: {},
+  objects: {
+    test: {
+      apiName: "test",
+      properties: {},
+    },
+  },
+} satisfies OntologyDefinition<"test">;


### PR DESCRIPTION
Adds stubs for `FoundryClient` and generating a back-compat interface. 
Here we're using a generated client to instantiate with the correct types from the metadata. 