### PR TITLE
SingleLinkImpl

### DIFF
--- a/packages/legacy-client/src/ontology-runtime/baseTypes/SingleLinkImpl.ts
+++ b/packages/legacy-client/src/ontology-runtime/baseTypes/SingleLinkImpl.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type GetLinkedObjectError, type Result } from "../ontologyProvider";
+import type { ClientContext } from "../ontologyProvider/calls/ClientContext";
+import { getLinkedObject } from "../ontologyProvider/calls/getLinkedObject";
+import type { SingleLink } from "./links";
+import type { OntologyObject } from "./OntologyObject";
+import type { ParameterValue } from "./ParameterValue";
+
+export class SingleLinkImpl<T extends OntologyObject = OntologyObject>
+  implements SingleLink<T>
+{
+  #context: ClientContext;
+  #sourceObjectType: string;
+  #sourcePrimaryKey: ParameterValue;
+  #targetObjectType: T["__apiName"];
+
+  constructor(
+    context: ClientContext,
+    sourceObjectType: string,
+    sourcePrimaryKey: ParameterValue,
+    targetObjectType: T["__apiName"],
+  ) {
+    this.#context = context;
+    this.#sourceObjectType = sourceObjectType;
+    this.#sourcePrimaryKey = sourcePrimaryKey;
+    this.#targetObjectType = targetObjectType;
+  }
+
+  async get(): Promise<Result<T, GetLinkedObjectError>> {
+    return getLinkedObject(
+      this.#context,
+      this.#sourceObjectType,
+      this.#sourcePrimaryKey,
+      this.#targetObjectType,
+    );
+  }
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/ErrorHandlers.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/ErrorHandlers.ts
@@ -235,6 +235,8 @@ export function handleGetLinkedObjectError(
         parameters.objectType,
         parameters.properties,
       );
+    case "ObjectsExceeded":
+      return handler.handleObjectsExceeded(error);
     case "PermissionDenied":
       return handler.handlePermissionDenied(error);
     case "Unauthorized":

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/Errors.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/Errors.ts
@@ -92,6 +92,7 @@ export type GetLinkedObjectError =
   | OntologySyncing
   | LinkedObjectNotFound
   | PropertiesNotFound
+  | ObjectsExceededLimit
   | CommonApiError;
 export type ListLinkedObjectsError =
   | ObjectsExceededLimit

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/ClientContext.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/ClientContext.ts
@@ -16,7 +16,7 @@
 
 import type { OntologyDefinition, ThinClient } from "@osdk/api";
 import type { OntologyObjectV2 } from "@osdk/gateway/types";
-import type { OntologyObject } from "../..";
+import type { OntologyObject } from "../../baseTypes";
 
 export interface ClientContext {
   client: ThinClient<any>;

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/ClientContext.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/ClientContext.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyDefinition, ThinClient } from "@osdk/api";
+import type { OntologyObjectV2 } from "@osdk/gateway/types";
+import type { OntologyObject } from "../..";
+
+export interface ClientContext {
+  client: ThinClient<any>;
+  ontology: OntologyDefinition<any>;
+  createObject<T extends OntologyObject>(
+    context: ClientContext,
+    objectTypeId: string,
+    properties: OntologyObjectV2,
+  ): T;
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObject.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObject.ts
@@ -15,11 +15,7 @@
  */
 
 import type { OntologyObject, ParameterValue } from "../../baseTypes";
-import type {
-  GetLinkedObjectError,
-  LinkedObjectNotFound,
-  ObjectsExceededLimit,
-} from "../Errors";
+import type { GetLinkedObjectError, LinkedObjectNotFound } from "../Errors";
 import { isErr, type Result } from "../Result";
 import type { ClientContext } from "./ClientContext";
 import { listLinkedObjects } from "./listLinkedObjects";
@@ -49,10 +45,15 @@ export async function getLinkedObject<
       {
         name: "Too many objects",
         message:
-          `There are multiple ${targetObjectType} objects for this object`,
-        errorName: "ObjectsExceededLimit",
-        errorType: "INVALID_ARGUMENT",
-      } satisfies ObjectsExceededLimit,
+          `There are multiple ${targetObjectType} objects for this object, but there should only be one`,
+        errorName: "LinkedObjectNotFound",
+        errorType: "NOT_FOUND",
+        linkType: targetObjectType,
+        linkedObjectType: sourceObjectType,
+        linkedObjectPrimaryKey: {
+          primaryKey: sourcePrimaryKey.toString(),
+        },
+      } satisfies LinkedObjectNotFound,
     );
   }
 

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObject.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObject.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyObject, ParameterValue } from "../..";
+import type { GetLinkedObjectError, Result } from "..";
+import { isErr } from "..";
+import type { ClientContext } from "./ClientContext";
+import { listLinkedObjects } from "./listLinkedObjects";
+import { createErrorResponse } from "./util/ResponseCreators";
+
+export async function getLinkedObject<
+  T extends OntologyObject = OntologyObject,
+>(
+  context: ClientContext,
+  sourceObjectType: string,
+  sourcePrimaryKey: ParameterValue,
+  targetObjectType: T["__apiName"],
+): Promise<Result<T, GetLinkedObjectError>> {
+  const result = await listLinkedObjects(
+    context,
+    sourceObjectType,
+    sourcePrimaryKey,
+    targetObjectType,
+  );
+
+  if (isErr(result)) {
+    return result;
+  }
+
+  if (result.type == "ok" && result.value.length > 1) {
+    return createErrorResponse(
+      new Error(
+        `There are multiple ${targetObjectType} objects for this object`,
+      ),
+    );
+  }
+
+  if (result.type == "ok" && result.value.length != 1) {
+    return createErrorResponse(
+      new Error(
+        `There are no ${targetObjectType} objects for this object`,
+      ),
+    );
+  }
+
+  return { type: "ok", value: result.value[0] };
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObjectsPage.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObjectsPage.ts
@@ -16,7 +16,7 @@
 
 import { createOpenApiRequest } from "@osdk/api";
 import { listLinkedObjectsV2 } from "@osdk/gateway/requests";
-import type { OntologyObject } from "../..";
+import type { OntologyObject } from "../../baseTypes";
 import type { ClientContext } from "./ClientContext";
 
 export async function getLinkedObjectsPage<T extends OntologyObject>(

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObjectsPage.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/getLinkedObjectsPage.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createOpenApiRequest } from "@osdk/api";
+import { listLinkedObjectsV2 } from "@osdk/gateway/requests";
+import type { OntologyObject } from "../..";
+import type { ClientContext } from "./ClientContext";
+
+export async function getLinkedObjectsPage<T extends OntologyObject>(
+  context: ClientContext,
+  sourceApiName: string,
+  primaryKey: any,
+  linkTypeApiName: string,
+  options?: { pageSize?: number; pageToken?: string },
+) {
+  const pagePromise = await listLinkedObjectsV2(
+    createOpenApiRequest(context.client.stack, context.client.fetch),
+    context.ontology.metadata.ontologyApiName,
+    sourceApiName,
+    primaryKey,
+    linkTypeApiName,
+    {
+      pageSize: options?.pageSize,
+      pageToken: options?.pageToken,
+      select: [],
+    },
+  );
+  return {
+    data: pagePromise.data.map(object => {
+      return context.createObject<T>(context, linkTypeApiName, object);
+    }),
+    nextPageToken: pagePromise.nextPageToken,
+  };
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/listLinkedObjects.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/listLinkedObjects.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import type { ListLinkedObjectsError, OntologyObject, Result } from "../..";
+import type { OntologyObject } from "../../baseTypes";
 import {
   handleListLinkedObjectsError,
   ListLinkedObjectsErrorHandler,
-} from "../..";
+} from "../ErrorHandlers";
+import type { ListLinkedObjectsError } from "../Errors";
+import type { Result } from "../Result";
 import type { ClientContext } from "./ClientContext";
 import { getLinkedObjectsPage } from "./getLinkedObjectsPage";
 import { wrapResult } from "./util/wrapResult";

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/listLinkedObjects.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/listLinkedObjects.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ListLinkedObjectsError, OntologyObject, Result } from "../..";
+import {
+  handleListLinkedObjectsError,
+  ListLinkedObjectsErrorHandler,
+} from "../..";
+import type { ClientContext } from "./ClientContext";
+import { getLinkedObjectsPage } from "./getLinkedObjectsPage";
+import { wrapResult } from "./util/wrapResult";
+
+export function listLinkedObjects<T extends OntologyObject>(
+  context: ClientContext,
+  sourceApiName: string,
+  primaryKey: any,
+  linkTypeApiName: T["__apiName"],
+): Promise<Result<T[], ListLinkedObjectsError>> {
+  return wrapResult(
+    async () => {
+      const allObjects: T[] = [];
+      let page = await getLinkedObjectsPage<T>(
+        context,
+        sourceApiName,
+        primaryKey,
+        linkTypeApiName,
+      );
+      for (const object of page.data) {
+        allObjects.push(object);
+      }
+      while (page.nextPageToken) {
+        page = await getLinkedObjectsPage<T>(
+          context,
+          sourceApiName,
+          primaryKey,
+          linkTypeApiName,
+          {
+            pageToken: page.nextPageToken,
+          },
+        );
+        for (const object of page.data) {
+          allObjects.push(object);
+        }
+      }
+      return allObjects;
+    },
+    e =>
+      handleListLinkedObjectsError(
+        new ListLinkedObjectsErrorHandler(),
+        e,
+        e.parameters,
+      ),
+  );
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/ResponseCreators.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/ResponseCreators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Err, Ok } from "../..";
+import type { Err, Ok } from "../../Result";
 
 export function createOkResponse<V>(value: V): Ok<V> {
   return { type: "ok", value };

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/ResponseCreators.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/ResponseCreators.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Err, Ok } from "../..";
+
+export function createOkResponse<V>(value: V): Ok<V> {
+  return { type: "ok", value };
+}
+
+export function createErrorResponse<E>(error: E): Err<E> {
+  return { type: "error", error };
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/wrapResult.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/wrapResult.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PalantirApiError } from "../../../../Errors";
+import type { FoundryApiError, Result } from "../..";
+import { createErrorResponse, createOkResponse } from "./ResponseCreators";
+
+export async function wrapResult<T, E extends FoundryApiError>(
+  apiCall: () => Promise<T>,
+  errorHandler: (palantirApiError: PalantirApiError) => E,
+): Promise<Result<T, E>> {
+  try {
+    const result = await apiCall();
+    return createOkResponse(result);
+  } catch (e) {
+    if (e instanceof PalantirApiError) {
+      return createErrorResponse(errorHandler(e));
+    } else {
+      // TODO this unknown used to be an UnknownError but it had casting problems
+      return createErrorResponse(e as unknown as E);
+    }
+  }
+}

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/wrapResult.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/calls/util/wrapResult.ts
@@ -15,7 +15,8 @@
  */
 
 import { PalantirApiError } from "../../../../Errors";
-import type { FoundryApiError, Result } from "../..";
+import type { FoundryApiError } from "../../Errors";
+import type { Result } from "../../Result";
 import { createErrorResponse, createOkResponse } from "./ResponseCreators";
 
 export async function wrapResult<T, E extends FoundryApiError>(

--- a/packages/legacy-client/src/ontology-runtime/ontologyProvider/errors/GetLinkedObjectErrorHandler.ts
+++ b/packages/legacy-client/src/ontology-runtime/ontologyProvider/errors/GetLinkedObjectErrorHandler.ts
@@ -18,6 +18,7 @@ import type { PalantirApiError } from "../../../Errors";
 import type {
   CompositePrimaryKeyNotSupported,
   LinkedObjectNotFound,
+  ObjectsExceededLimit,
   ObjectTypeNotFound,
   ObjectTypeNotSynced,
   OntologySyncing,
@@ -139,6 +140,15 @@ export class GetLinkedObjectErrorHandler extends DefaultErrorHandler {
       statusCode: error.statusCode,
       objectType,
       properties,
+    };
+  }
+
+  handleObjectsExceeded(error: PalantirApiError): ObjectsExceededLimit {
+    return {
+      name: error.errorName,
+      message: error.message,
+      errorName: "ObjectsExceededLimit",
+      errorType: "INVALID_ARGUMENT",
     };
   }
 }


### PR DESCRIPTION
Lots of underneath the hood code churn to implement a relatively straightforward `SingleLinkImpl` class.

- Introduce `ClientContext` which is the object that gets passed around internally to preserve the information required to actually perform network requests.
- Add `ObjectsExceeded` to GetLinkedObjectError in order to make GetLinkedObjectsError assignable
- Start breaking out OntologyProvider into individual methods
- Rework of `getLinkedObject` logic in order to fix compile errors that were not found in the older implementation.

Skipping any refactoring of the error handling for now, we can do that in a later PR.