### PR TITLE
Clean up @osdk/api 'internal' exports

### DIFF
--- a/packages/api/src/client/createOpenApiRequest.test.ts
+++ b/packages/api/src/client/createOpenApiRequest.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { default as createOpenApiRequest } from "./createOpenApiRequest";
+import { createOpenApiRequest } from "./createOpenApiRequest";
 
 describe("createOpenApiRequest", () => {
   it("should construct request correctly", async () => {

--- a/packages/api/src/client/createOpenApiRequest.ts
+++ b/packages/api/src/client/createOpenApiRequest.ts
@@ -16,7 +16,7 @@
 
 import type { OpenApiRequest } from "@osdk/gateway/types";
 
-export default function createOpenApiRequest<TExpectedResponse>(
+export function createOpenApiRequest<TExpectedResponse>(
   basePath: string,
   fetchFn: typeof fetch,
   contextPath: string = "/api",

--- a/packages/api/src/client/internal/net/index.ts
+++ b/packages/api/src/client/internal/net/index.ts
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export { default as createOpenApiRequest } from "./createOpenApiRequest";
 export * as Wire from "./types";

--- a/packages/api/src/client/object/aggregateOrThrow.ts
+++ b/packages/api/src/client/object/aggregateOrThrow.ts
@@ -18,13 +18,13 @@ import { aggregateObjectsV2 } from "@osdk/gateway/requests";
 import type { AggregateObjectsRequestV2 } from "@osdk/gateway/types";
 import invariant from "tiny-invariant";
 import type { ObjectTypesFrom, OntologyDefinition } from "../../ontology";
+import { createOpenApiRequest } from "../createOpenApiRequest";
 import {
   legacyToModernSingleAggregationResult,
   modernToLegacyAggregationClause,
   modernToLegacyGroupByClause,
   modernToLegacyWhereClause,
 } from "../internal/conversions";
-import { createOpenApiRequest } from "../internal/net";
 import type {
   AggregationResultsWithGroups,
   AggregationsResults,

--- a/packages/api/src/client/object/fetchPageOrThrow.ts
+++ b/packages/api/src/client/object/fetchPageOrThrow.ts
@@ -23,8 +23,8 @@ import type {
   PropertyKeysFrom,
 } from "../../ontology";
 import type { NOOP } from "../../util";
+import { createOpenApiRequest } from "../createOpenApiRequest";
 import type { Wire } from "../internal/net";
-import { createOpenApiRequest } from "../internal/net";
 import type { PageResult } from "../PageResult";
 import type { ThinClient } from "../ThinClient";
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,12 +16,9 @@
 
 export { createClient, createThinClient, isOk } from "./client";
 export type { Client, ObjectSet, ResultOrError, ThinClient } from "./client";
-export { default as createOpenApiRequest } from "./client/internal/net/createOpenApiRequest";
-export type {
-  BaseGroupValue,
-  Bucketing,
-  GroupValue,
-} from "./client/internal/net/types";
+
+export { createOpenApiRequest } from "./client/createOpenApiRequest";
+
 export type { WhereClause } from "./client/query";
 export type { OsdkObject } from "./ontology";
 

--- a/packages/legacy-client/src/ontology-runtime/aggregations/aggregationConverters.ts
+++ b/packages/legacy-client/src/ontology-runtime/aggregations/aggregationConverters.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { BaseGroupValue, Bucketing, GroupValue } from "@osdk/api";
 import type {
   AggregateObjectSetResponseV2,
   AggregateObjectsResponseItemV2,
@@ -23,6 +22,11 @@ import type {
 import type { ObjectSetDefinition } from "../baseTypes";
 import { LocalDate, Timestamp } from "../baseTypes";
 import { buildBucketObject } from "../ontologyProvider/AggregationUtils";
+import type {
+  BaseGroupValue,
+  Bucketing,
+  GroupValue,
+} from "./aggregationConverter";
 import { visitInternalBucketing } from "./Aggregations";
 import type {
   AggregationClause,


### PR DESCRIPTION
- Move createOpenApiRequest out of the internal/net directory
- Remove exports of other internal/net types and used the types in @osdk/legacy-client instead