### PR TITLE
Standardize caching

### DIFF
--- a/packages/legacy-client/src/client/convertWireToOsdkObject.test.ts
+++ b/packages/legacy-client/src/client/convertWireToOsdkObject.test.ts
@@ -85,6 +85,48 @@ describe("convertWireToOsdkObject", () => {
       geoShapeArray: [expectedGeoShape],
     });
   });
+
+  it("reuses the same prototype for subsequent creations", () => {
+    const object1 = convertWireToOsdkObject<
+      "Task",
+      typeof MockOntology
+    >(client, "Task", {
+      __rid: "rid.1",
+      __primaryKey: 1,
+      __apiName: "Task",
+      id: 1,
+    });
+
+    const object2 = convertWireToOsdkObject<
+      "Task",
+      typeof MockOntology
+    >(client, "Task", {
+      __rid: "rid.2",
+      __primaryKey: 2,
+      __apiName: "Task",
+      id: 2,
+    });
+
+    expect(Object.getPrototypeOf(object1)).toBe(Object.getPrototypeOf(object2));
+  });
+
+  it("adds toString method which performs a json stringification", () => {
+    const wireObject = {
+      id: 1,
+      __primaryKey: 1,
+      __apiName: "Task",
+      __rid: "rid.1",
+    } as const;
+
+    const object = convertWireToOsdkObject<
+      "Task",
+      typeof MockOntology
+    >(client, "Task", wireObject);
+
+    expect(object.toString()).toEqual(
+      JSON.stringify(wireObject, null, 2),
+    );
+  });
 });
 
 const objectWithAllPropertyTypes = {

--- a/packages/legacy-client/src/client/convertWireToOsdkObject.ts
+++ b/packages/legacy-client/src/client/convertWireToOsdkObject.ts
@@ -31,21 +31,22 @@ import {
   GeoShape,
   LocalDate,
   type OntologyObject,
-  type ParameterValue,
   Timestamp,
 } from "../ontology-runtime/baseTypes";
 import { MultiLinkImpl } from "../ontology-runtime/baseTypes/MultiLinkImpl";
 import { SingleLinkImpl } from "../ontology-runtime/baseTypes/SingleLinkImpl";
+import { createCachedOntologyTransform } from "./objectSets/createCachedOntologyTransform";
 
+const getPrototype = createCachedOntologyTransform(createPrototype);
 function createPrototype<
   T extends keyof O["objects"] & string,
   O extends OntologyDefinition<any>,
 >(
-  context: ThinClient<O>,
-  primaryKey: ParameterValue,
+  ontology: O,
   type: T,
+  client: ThinClient<O>,
 ) {
-  const objDef = context.ontology.objects[type];
+  const objDef = ontology.objects[type];
   const proto = {};
 
   Object.defineProperty(proto, "__apiName", { get: () => type });
@@ -54,7 +55,7 @@ function createPrototype<
   proto.toString = function() {
     const obj: Record<string, unknown> = {};
     const self = this as OsdkLegacyPropertiesFrom<O, T> & OntologyObject<T>;
-    for (const prop of Object.keys(context.ontology.objects[type].properties)) {
+    for (const prop of Object.keys(objDef.properties)) {
       obj[prop] = self[prop];
     }
     obj["__primaryKey"] = self.__primaryKey;
@@ -71,16 +72,16 @@ function createPrototype<
       get: function() {
         if (multiplicity == true) {
           return new MultiLinkImpl(
-            context,
+            client,
             objDef.apiName,
-            primaryKey,
+            this.__primaryKey,
             targetType,
           );
         } else {
           return new SingleLinkImpl(
-            context,
+            client,
             objDef.apiName,
-            primaryKey,
+            this.__primaryKey,
             targetType,
           );
         }
@@ -91,10 +92,6 @@ function createPrototype<
   return proto as OsdkLegacyLinksFrom<O, T>;
 }
 
-/**
- * First key is ontologyRid, second key is apiName
- */
-const cache = new Map<string, Map<string, any>>();
 export function convertWireToOsdkObject<
   T extends ObjectTypesFrom<O> & string,
   O extends OntologyDefinition<any>,
@@ -103,25 +100,7 @@ export function convertWireToOsdkObject<
   apiName: T,
   obj: OntologyObjectV2,
 ): OsdkLegacyObjectFrom<O, T> {
-  const ontologyCache = cache.get(client.ontology.metadata.ontologyRid);
-  let proto = ontologyCache?.get(apiName);
-  if (proto == null) {
-    proto = createPrototype(
-      client,
-      obj.__primaryKey,
-      apiName,
-    );
-
-    if (ontologyCache == null) {
-      cache.set(
-        client.ontology.metadata.ontologyRid,
-        new Map([[apiName, proto]]),
-      );
-    } else {
-      ontologyCache.set(apiName, proto);
-    }
-  }
-
+  const proto = getPrototype(client.ontology, apiName, client);
   Object.setPrototypeOf(obj, proto);
   setPropertyAccessors<T, O>(client, apiName, obj);
 

--- a/packages/legacy-client/src/client/objectSets/createCachedOntologyTransform.ts
+++ b/packages/legacy-client/src/client/objectSets/createCachedOntologyTransform.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectDefinition,
+  ObjectTypesFrom,
+  OntologyDefinition,
+} from "@osdk/api";
+
+/**
+ * Creates a getter function that caches based on the ontology.objects[type] value
+ *
+ * Any extra arguments are passed through, but only the first args passed in will be used and are not considered as part of the caching
+ */
+export function createCachedOntologyTransform<
+  O extends OntologyDefinition<any>,
+  K extends ObjectTypesFrom<O>,
+  T,
+  A extends any[],
+>(
+  creator: (ontology: O, type: K, ...args: A) => T,
+) {
+  // We can use the ObjectDefinition as the key because it will be a globally unique singleton
+  // Use Map instead of WeakMap here so usage for things like object prototypes do not churn over time
+  const cache = new Map<ObjectDefinition<any, any>, T>();
+
+  return (ontology: O, type: K, ...args: A) => {
+    const objectDefinition = ontology.objects[type];
+    let result = cache.get(objectDefinition);
+
+    if (result == null) {
+      result = creator(ontology, type, ...args);
+      cache.set(objectDefinition, result);
+    }
+
+    return result;
+  };
+}

--- a/packages/legacy-client/src/client/objectSets/createObjectSetAggregationStep.ts
+++ b/packages/legacy-client/src/client/objectSets/createObjectSetAggregationStep.ts
@@ -38,9 +38,20 @@ import type {
   MultipleAggregateSelection,
 } from "../interfaces/aggregations";
 import type { OsdkLegacyObjectFrom } from "../OsdkObject";
+import { createCachedOntologyTransform } from "./createCachedOntologyTransform";
 import { mapPropertiesToAggregatableProperties } from "./mapPropertiesToAggregatableProperties";
 import { mapPropertiesToGroupByProperties } from "./mapPropertiesToGroupByProperties";
 import { mapPropertiesToMultipleAggregationProperties } from "./mapPropertiesToMultipleAggregationProperties";
+
+const getAggregatableProperties = createCachedOntologyTransform(
+  mapPropertiesToAggregatableProperties,
+);
+const getGroupableProperties = createCachedOntologyTransform(
+  mapPropertiesToGroupByProperties,
+);
+const getMultipleAggregationProperties = createCachedOntologyTransform(
+  mapPropertiesToMultipleAggregationProperties,
+);
 
 export function createObjectSetAggregationStep<
   O extends OntologyDefinition<any>,
@@ -55,20 +66,18 @@ export function createObjectSetAggregationStep<
   MultipleAggregateSelection<OsdkLegacyObjectFrom<O, K>>,
   GroupBySelections<OsdkLegacyObjectFrom<O, K>>
 > {
-  // TODO defer these until they are needed and cache them by ontologyRid/objectType
-  const aggregatableProperties = mapPropertiesToAggregatableProperties(
+  const aggregatableProperties = getAggregatableProperties(
     client.ontology,
     type,
   );
-  const groupableProperties = mapPropertiesToGroupByProperties(
+  const groupableProperties = getGroupableProperties(
     client.ontology,
     type,
   );
-  const multipleAggregationProperties =
-    mapPropertiesToMultipleAggregationProperties(
-      client.ontology,
-      type,
-    );
+  const multipleAggregationProperties = getMultipleAggregationProperties(
+    client.ontology,
+    type,
+  );
 
   return {
     aggregate(aggregateBuilder) {


### PR DESCRIPTION
Add `createCachedOntologyTransform` that gives us an easy shorthand to defer and cache computation from `ObjectDefinition -> T`.

Use this for the object prototypes, and the aggregatable, groupable, multipleAggregation properties.

I can add this to the orderBy and searchFilter code as well if we like this direction.