### PR TITLE
Rework convertWireToOsdkObject caching

### DIFF
--- a/packages/legacy-client/src/client/actions.test.ts
+++ b/packages/legacy-client/src/client/actions.test.ts
@@ -42,7 +42,7 @@ import {
   mockFetchResponse,
 } from "../util/test/fetchUtils";
 import { MOCK_ORIGIN } from "../util/test/mocks/mockMetadata";
-import { mockTodoObject } from "../util/test/mocks/mockObjects";
+import { getMockTodoObject } from "../util/test/mocks/mockObjects";
 import { unwrapResultOrThrow } from "../util/test/resultUtils";
 import { type Actions, createActionProxy } from "./actions";
 import { createBaseOsdkObjectSet } from "./objectSets/OsdkObjectSet";
@@ -176,18 +176,20 @@ describe("Actions", () => {
 
       const value = unwrapResultOrThrow(actionResponse);
       assert(value.edits.type === "edits");
-      mockFetchResponse(fetch, mockTodoObject);
+      mockFetchResponse(fetch, getMockTodoObject());
       const loadAddedObject = await value.edits.added[0].get();
 
       expectFetchToBeCalledWithGet(fetch, `Ontology/objects/Todo/1`);
       const createdObject = unwrapResultOrThrow(loadAddedObject);
-      expect(createdObject.__primaryKey).toEqual(mockTodoObject.__primaryKey);
+      expect(createdObject.__primaryKey).toEqual(
+        getMockTodoObject().__primaryKey,
+      );
     });
   });
 
   it("proxies action calls transforms arguments", async () => {
     const taskOs = createBaseOsdkObjectSet(client, "Task");
-    mockFetchResponse(fetch, mockTodoObject);
+    mockFetchResponse(fetch, getMockTodoObject());
     const taskObjectResult = await taskOs.get(1);
     const taskObject = unwrapResultOrThrow(taskObjectResult);
 

--- a/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
+++ b/packages/legacy-client/src/client/objectSets/OsdkObjectSet.test.ts
@@ -32,8 +32,8 @@ import {
 import type { ObjectSetDefinition } from "../../ontology-runtime";
 import { MockOntology } from "../../util/test";
 import {
-  mockTaskObject,
-  mockTodoObject,
+  getMockTaskObject,
+  getMockTodoObject,
 } from "../../util/test/mocks/mockObjects";
 import { createBaseOsdkObjectSet } from "./OsdkObjectSet";
 
@@ -208,7 +208,7 @@ describe("OsdkObjectSet", () => {
 
   it("supports select methods - all", async () => {
     const os = createBaseTodoObjectSet(client);
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const result = await os.select(["id", "body", "complete"]).all();
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(
@@ -225,7 +225,7 @@ describe("OsdkObjectSet", () => {
 
   it("supports select methods - page", async () => {
     const os = createBaseTodoObjectSet(client);
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const result = await os.select(["id", "body", "complete"]).page({
       pageSize: 5,
       pageToken: "fakePageToken",
@@ -247,7 +247,7 @@ describe("OsdkObjectSet", () => {
 
   it("supports select methods - get", async () => {
     const os = createBaseTodoObjectSet(client);
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const result = await os.select(["id", "body", "complete"]).get("123");
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(
@@ -263,21 +263,21 @@ describe("OsdkObjectSet", () => {
 
   it("supports round-trip of circular links", async () => {
     const os = createBaseTodoObjectSet(client);
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const todoResponse = await os.get("1");
 
     if (!isOk(todoResponse)) {
       expect.fail("todo response was not ok");
     }
 
-    mockObjectPage([mockTaskObject]);
+    mockObjectPage([getMockTaskObject()]);
     const taskResponse = await todoResponse.value.linkedTask.get();
 
     if (!isOk(taskResponse)) {
       expect.fail("task response was not ok");
     }
 
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const linkedTodosResponse = await taskResponse.value.linkedTodos.all();
 
     if (!isOk(linkedTodosResponse)) {
@@ -289,7 +289,7 @@ describe("OsdkObjectSet", () => {
 
   it("loads a page", async () => {
     const os = createBaseTodoObjectSet(client);
-    mockObjectPage([mockTodoObject]);
+    mockObjectPage([getMockTodoObject()]);
     const page = await os.page({ pageSize: 1 });
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(

--- a/packages/legacy-client/src/client/objectSets/createCachedOntologyTransform.ts
+++ b/packages/legacy-client/src/client/objectSets/createCachedOntologyTransform.ts
@@ -29,20 +29,19 @@ export function createCachedOntologyTransform<
   O extends OntologyDefinition<any>,
   K extends ObjectTypesFrom<O>,
   T,
-  A extends any[],
 >(
-  creator: (ontology: O, type: K, ...args: A) => T,
+  creator: (ontology: O, type: K) => T,
 ) {
   // We can use the ObjectDefinition as the key because it will be a globally unique singleton
   // Use Map instead of WeakMap here so usage for things like object prototypes do not churn over time
   const cache = new Map<ObjectDefinition<any, any>, T>();
 
-  return (ontology: O, type: K, ...args: A) => {
+  return (ontology: O, type: K) => {
     const objectDefinition = ontology.objects[type];
     let result = cache.get(objectDefinition);
 
     if (result == null) {
-      result = creator(ontology, type, ...args);
+      result = creator(ontology, type);
       cache.set(objectDefinition, result);
     }
 

--- a/packages/legacy-client/src/util/test/mocks/mockObjects.ts
+++ b/packages/legacy-client/src/util/test/mocks/mockObjects.ts
@@ -16,17 +16,21 @@
 
 import type { OntologyObjectV2 } from "@osdk/gateway/types";
 
-export const mockTodoObject = {
-  __apiName: "Todo",
-  __primaryKey: 1,
-  __rid: "ri.a.b.c.d",
-  id: "123",
-  body: "body",
-  complete: false,
-} satisfies OntologyObjectV2;
+export function getMockTodoObject(): OntologyObjectV2 {
+  return {
+    __apiName: "Todo",
+    __primaryKey: 1,
+    __rid: "ri.a.b.c.d",
+    id: "123",
+    body: "body",
+    complete: false,
+  };
+}
 
-export const mockTaskObject = {
-  __apiName: "Task",
-  __primaryKey: 1,
-  id: 1,
-} satisfies OntologyObjectV2;
+export function getMockTaskObject(): OntologyObjectV2 {
+  return {
+    __apiName: "Task",
+    __primaryKey: 1,
+    id: 1,
+  };
+}


### PR DESCRIPTION
Caching the object prototypes with an implied client means that multiple clients for the same ontology could accidentally use the incorrect client.

Instead we use the same prototype but pass through the ThinClient reference as a non-enumerable symbol on the object itself.