### PR TITLE
Relocate ontology(Actions|Queries|Objects) into their respective directories

### DIFF
--- a/examples/one_dot_one/src/generatedNoCheck/Ontology.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/Ontology.ts
@@ -1,15 +1,15 @@
 import type { OntologyDefinition } from '@osdk/api';
 import type { Ontology as ClientOntology } from '@osdk/legacy-client';
+import type { Actions } from './ontology/actions/Actions';
 import { actionTakesAllParameterTypes } from './ontology/actions/actionTakesAllParameterTypes';
 import { createTodo } from './ontology/actions/createTodo';
 import { ObjectTypeWithAllPropertyTypes } from './ontology/objects/ObjectTypeWithAllPropertyTypes';
+import type { Objects } from './ontology/objects/Objects';
 import { Person } from './ontology/objects/Person';
 import { Todo } from './ontology/objects/Todo';
+import type { Queries } from './ontology/queries/Queries';
 import { getTodoCount } from './ontology/queries/getTodoCount';
 import { queryTakesAllParameterTypes } from './ontology/queries/queryTakesAllParameterTypes';
-import type { Actions } from './ontologyActions';
-import type { Objects } from './ontologyObjects';
-import type { Queries } from './ontologyQueries';
 
 export const Ontology: {
   metadata: {

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/actions/Actions.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/actions/Actions.ts
@@ -9,9 +9,9 @@ import type {
   Result,
   Timestamp,
 } from '@osdk/legacy-client';
-import type { ObjectTypeWithAllPropertyTypes } from './ontology/objects/ObjectTypeWithAllPropertyTypes';
-import type { Person } from './ontology/objects/Person';
-import type { Todo } from './ontology/objects/Todo';
+import type { ObjectTypeWithAllPropertyTypes } from '../objects/ObjectTypeWithAllPropertyTypes';
+import type { Person } from '../objects/Person';
+import type { Todo } from '../objects/Todo';
 export interface Actions {
   /**
    * An action which takes different types of parameters

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Objects.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Objects.ts
@@ -1,5 +1,7 @@
 import { BaseObjectSet } from '@osdk/legacy-client';
-import { ObjectTypeWithAllPropertyTypes, Person, Todo } from './ontology/objects';
+import type { ObjectTypeWithAllPropertyTypes } from './ObjectTypeWithAllPropertyTypes';
+import type { Person } from './Person';
+import type { Todo } from './Todo';
 
 export interface Objects {
   Todo: BaseObjectSet<Todo>;

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/queries/Queries.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/queries/Queries.ts
@@ -10,7 +10,7 @@ import type {
   Timestamp,
   TwoDimensionalAggregation,
 } from '@osdk/legacy-client';
-import type { Todo } from './ontology/objects/Todo';
+import type { Todo } from '../objects/Todo';
 
 export interface Queries {
   /**

--- a/packages/generator/src/v1.1/generateActions.test.ts
+++ b/packages/generator/src/v1.1/generateActions.test.ts
@@ -32,7 +32,7 @@ describe(generateActions, () => {
 
     expect(helper.minimalFiles.writeFile).toBeCalled();
 
-    expect(helper.getFiles()[`${BASE_PATH}/ontologyActions.ts`])
+    expect(helper.getFiles()[`${BASE_PATH}/Actions.ts`])
       .toMatchInlineSnapshot(`
         "import type {
           ActionError,
@@ -41,7 +41,7 @@ describe(generateActions, () => {
           Edits,
           Result,
         } from '@osdk/legacy-client';
-        import type { Todo } from './ontology/objects/Todo';
+        import type { Todo } from '../objects/Todo';
         export interface Actions {
           /**
            * An action which takes different types of parameters

--- a/packages/generator/src/v1.1/generateActions.ts
+++ b/packages/generator/src/v1.1/generateActions.ts
@@ -80,13 +80,14 @@ export async function generateActions(
     );
   }
 
+  await fs.mkdir(outDir, { recursive: true });
   await fs.writeFile(
-    path.join(outDir, `ontologyActions.ts`),
+    path.join(outDir, "Actions.ts"),
     await formatTs(`
     import type { ObjectSet, LocalDate, Timestamp, Attachment, Edits, ActionExecutionOptions, ActionError, Result, ActionResponseFromOptions } from "@osdk/legacy-client";
     ${
       Array.from(importedObjects).map(importedObject =>
-        `import type { ${importedObject} } from "./ontology/objects/${importedObject}";`
+        `import type { ${importedObject} } from "../objects/${importedObject}";`
       ).join("\n")
     }
     export interface Actions {

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -34,27 +34,31 @@ export async function generateClientSdkVersionOneDotOne(
   fs: MinimalFs,
   outDir: string,
 ) {
+  const objectsDir = path.join(outDir, "ontology", "objects");
+  const actionsDir = path.join(outDir, "ontology", "actions");
+  const queriesDir = path.join(outDir, "ontology", "queries");
+
   const sanitizedOntology = sanitizeMetadata(ontology);
   await generateFoundryClientFile(fs, outDir);
   await generateMetadataFile(sanitizedOntology, fs, outDir);
   await generateOntologyIndexFile(fs, path.join(outDir, "ontology"));
-  await generateObjectsInterfaceFile(sanitizedOntology, fs, outDir);
+  await generateObjectsInterfaceFile(sanitizedOntology, fs, objectsDir);
   await generatePerObjectInterfaceAndDataFiles(
     sanitizedOntology,
     fs,
-    path.join(outDir, "ontology", "objects"),
+    objectsDir,
   );
-  await generateActions(sanitizedOntology, fs, outDir);
+  await generateActions(sanitizedOntology, fs, actionsDir);
   await generatePerActionDataFiles(
     sanitizedOntology,
     fs,
-    path.join(outDir, "ontology", "actions"),
+    actionsDir,
   );
-  await generateQueries(sanitizedOntology, fs, outDir);
+  await generateQueries(sanitizedOntology, fs, queriesDir);
   await generatePerQueryDataFiles(
     sanitizedOntology,
     fs,
-    path.join(outDir, "ontology", "queries"),
+    queriesDir,
   );
   await generateIndexFile(fs, outDir);
 }

--- a/packages/generator/src/v1.1/generateMetadataFile.test.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.test.ts
@@ -37,13 +37,13 @@ describe(generateMetadataFile, () => {
     ).toMatchInlineSnapshot(`
       "import type { OntologyDefinition } from '@osdk/api';
       import type { Ontology as ClientOntology } from '@osdk/legacy-client';
+      import type { Actions } from './ontology/actions/Actions';
       import { markTodoCompleted } from './ontology/actions/markTodoCompleted';
+      import type { Objects } from './ontology/objects/Objects';
       import { Person } from './ontology/objects/Person';
       import { Todo } from './ontology/objects/Todo';
+      import type { Queries } from './ontology/queries/Queries';
       import { getCount } from './ontology/queries/getCount';
-      import type { Actions } from './ontologyActions';
-      import type { Objects } from './ontologyObjects';
-      import type { Queries } from './ontologyQueries';
 
       export const Ontology: {
         metadata: {

--- a/packages/generator/src/v1.1/generateMetadataFile.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.ts
@@ -35,9 +35,9 @@ export async function generateMetadataFile(
     await formatTs(`
   import type { OntologyDefinition } from "@osdk/api";
   import type { Ontology as ClientOntology } from "@osdk/legacy-client";
-  import type { Objects } from "./ontologyObjects";
-  import type { Actions } from "./ontologyActions";
-  import type { Queries } from "./ontologyQueries";
+  import type { Objects } from "./ontology/objects/Objects";
+  import type { Actions } from "./ontology/actions/Actions";
+  import type { Queries } from "./ontology/queries/Queries";
   ${
       objectNames.map((name) =>
         `import {${name}} from "./ontology/objects/${name}";`

--- a/packages/generator/src/v1.1/generateObjectsInterfaceFile.test.ts
+++ b/packages/generator/src/v1.1/generateObjectsInterfaceFile.test.ts
@@ -33,10 +33,11 @@ describe(generateObjectsInterfaceFile, () => {
     expect(helper.minimalFiles.writeFile).toBeCalled();
 
     expect(
-      helper.getFiles()[`${BASE_PATH}/ontologyObjects.ts`],
+      helper.getFiles()[`${BASE_PATH}/Objects.ts`],
     ).toMatchInlineSnapshot(`
       "import { BaseObjectSet } from '@osdk/legacy-client';
-      import { Person, Todo } from './ontology/objects';
+      import type { Person } from './Person';
+      import type { Todo } from './Todo';
 
       export interface Objects {
         Todo: BaseObjectSet<Todo>;

--- a/packages/generator/src/v1.1/generateObjectsInterfaceFile.ts
+++ b/packages/generator/src/v1.1/generateObjectsInterfaceFile.ts
@@ -16,7 +16,6 @@
 
 import path from "node:path";
 import type { MinimalFs } from "../MinimalFs";
-import { commaSeparatedIdentifiers } from "../util/commaSeparatedIdentifiers";
 import { formatTs } from "../util/test/formatTs";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
 
@@ -25,13 +24,16 @@ export async function generateObjectsInterfaceFile(
   fs: MinimalFs,
   outDir: string,
 ) {
+  await fs.mkdir(outDir, { recursive: true });
   await fs.writeFile(
-    path.join(outDir, "ontologyObjects.ts"),
+    path.join(outDir, "Objects.ts"),
     await formatTs(`
     import { BaseObjectSet } from "@osdk/legacy-client";
-    import { ${
-      commaSeparatedIdentifiers(Object.keys(ontology.objectTypes))
-    } } from "./ontology/objects";
+    ${
+      Array.from(Object.keys(ontology.objectTypes)).map(importedObject =>
+        `import type { ${importedObject} } from "./${importedObject}";`
+      ).join("\n")
+    }
     
     export interface Objects {
       ${

--- a/packages/generator/src/v1.1/generateQueries.test.ts
+++ b/packages/generator/src/v1.1/generateQueries.test.ts
@@ -19,7 +19,7 @@ import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
 import { TodoWireOntology } from "../util/test/TodoWireOntology";
 import { generateQueries } from "./generateQueries";
 
-describe("generateQueries", () => {
+describe(generateQueries, () => {
   it("generates queries interface", async () => {
     const helper = createMockMinimalFiles();
     const BASE_PATH = "/foo";
@@ -28,7 +28,7 @@ describe("generateQueries", () => {
 
     expect(helper.minimalFiles.writeFile).toBeCalled();
 
-    expect(helper.getFiles()[`${BASE_PATH}/ontologyQueries.ts`])
+    expect(helper.getFiles()[`${BASE_PATH}/Queries.ts`])
       .toMatchInlineSnapshot(`
         "import type { QueryError, QueryResponse, Result } from '@osdk/legacy-client';
 

--- a/packages/generator/src/v1.1/generateQueries.ts
+++ b/packages/generator/src/v1.1/generateQueries.ts
@@ -79,13 +79,14 @@ export async function generateQueries(
     );
   }
 
+  await fs.mkdir(outDir, { recursive: true });
   await fs.writeFile(
-    path.join(outDir, `ontologyQueries.ts`),
+    path.join(outDir, "Queries.ts"),
     await formatTs(`
     import type { QueryResponse, QueryError, Result, Timestamp, LocalDate, Range, Attachment, ObjectSet, TwoDimensionalAggregation, ThreeDimensionalAggregation  } from "@osdk/legacy-client";
     ${
       Array.from(importedObjects).map(importedObject =>
-        `import type { ${importedObject} } from "./ontology/objects/${importedObject}";`
+        `import type { ${importedObject} } from "../objects/${importedObject}";`
       ).join("\n")
     }
 


### PR DESCRIPTION
To match the older package layout a little more closely