### PR TITLE
Check builds with node 18, 20, and 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build and Test
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20, 21]
 
     steps:
       - name: Check out code
@@ -25,7 +28,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node }}
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Omitting 16 on purpose because it is no longer receiving security updates, and some of the tests depend on the [native fetch](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental) implementation.