### PR TITLE
Typescript 4.9 support for v1.1 code

### DIFF
--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -52,10 +52,28 @@ function standardPackageRules(shared) {
   return [
     standardTsconfig({
       ...shared,
+      excludePackages: [...shared.excludePackages, "@osdk/examples.basic.**"],
       options: {
         file: "tsconfig.json",
         template: {
-          extends: "tsconfig/base",
+          extends: "../../monorepo/tsconfig/tsconfig.base.json",
+
+          compilerOptions: {
+            rootDir: "src",
+            outDir: "build/types",
+            composite: true,
+          },
+          include: ["./src/**/*", ".eslintrc.cjs"],
+        },
+      },
+    }),
+    standardTsconfig({
+      ...shared,
+      includePackages: ["@osdk/examples.basic.**"],
+      options: {
+        file: "tsconfig.json",
+        template: {
+          extends: "../../../monorepo/tsconfig/tsconfig.base.json",
 
           compilerOptions: {
             rootDir: "src",

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -41,10 +41,6 @@ const formatedGeneratorHelper = (contents, ext) => async (context) => {
   return result.stdout;
 };
 
-function generateFormattedJson(o) {
-  return formatedGeneratorHelper(JSON.stringify(o), "json");
-}
-
 /**
  * @param {Omit<import("@monorepolint/config").RuleEntry<>,"options" | "id">} shared
  */
@@ -82,6 +78,25 @@ function standardPackageRules(shared) {
           },
           include: ["./src/**/*", ".eslintrc.cjs"],
         },
+      },
+    }),
+    // most packages can use the newest typescript, but we enforce that @osdk/example.one.dot.one uses TS4.9
+    // so that we get build-time checking to make sure we don't regress v1.1 clients using an older Typescript.
+    requireDependency({
+      ...shared,
+      excludePackages: [
+        ...shared.excludePackages,
+        "@osdk/examples.one.dot.one",
+        "@osdk/examples.basic.cli",
+      ],
+      options: {
+        devDependencies: { typescript: "^5.2.2" },
+      },
+    }),
+    requireDependency({
+      includePackages: ["@osdk/examples.one.dot.one"],
+      options: {
+        devDependencies: { typescript: "^4.9.0" },
       },
     }),
     packageScript({

--- a/.monorepolint.config.mjs
+++ b/.monorepolint.config.mjs
@@ -41,6 +41,22 @@ const formatedGeneratorHelper = (contents, ext) => async (context) => {
   return result.stdout;
 };
 
+function getTsconfigOptions(baseTsconfigPath) {
+  return {
+    file: "tsconfig.json",
+    template: {
+      extends: baseTsconfigPath,
+
+      compilerOptions: {
+        rootDir: "src",
+        outDir: "build/types",
+        composite: true,
+      },
+      include: ["./src/**/*", ".eslintrc.cjs"],
+    },
+  };
+}
+
 /**
  * @param {Omit<import("@monorepolint/config").RuleEntry<>,"options" | "id">} shared
  */
@@ -49,36 +65,14 @@ function standardPackageRules(shared) {
     standardTsconfig({
       ...shared,
       excludePackages: [...shared.excludePackages, "@osdk/examples.basic.**"],
-      options: {
-        file: "tsconfig.json",
-        template: {
-          extends: "../../monorepo/tsconfig/tsconfig.base.json",
-
-          compilerOptions: {
-            rootDir: "src",
-            outDir: "build/types",
-            composite: true,
-          },
-          include: ["./src/**/*", ".eslintrc.cjs"],
-        },
-      },
+      options: getTsconfigOptions("../../monorepo/tsconfig/tsconfig.base.json"),
     }),
     standardTsconfig({
       ...shared,
       includePackages: ["@osdk/examples.basic.**"],
-      options: {
-        file: "tsconfig.json",
-        template: {
-          extends: "../../../monorepo/tsconfig/tsconfig.base.json",
-
-          compilerOptions: {
-            rootDir: "src",
-            outDir: "build/types",
-            composite: true,
-          },
-          include: ["./src/**/*", ".eslintrc.cjs"],
-        },
-      },
+      options: getTsconfigOptions(
+        "../../../monorepo/tsconfig/tsconfig.base.json",
+      ),
     }),
     // most packages can use the newest typescript, but we enforce that @osdk/example.one.dot.one uses TS4.9
     // so that we get build-time checking to make sure we don't regress v1.1 clients using an older Typescript.

--- a/examples/basic/cli/tsconfig.json
+++ b/examples/basic/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/examples/basic/sdk/tsconfig.json
+++ b/examples/basic/sdk/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/examples/one_dot_one/package.json
+++ b/examples/one_dot_one/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^5.2.2"
+    "typescript": "^4.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/examples/one_dot_one/tsconfig.json
+++ b/examples/one_dot_one/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/api/src/ontology/index.ts
+++ b/packages/api/src/ontology/index.ts
@@ -14,9 +14,52 @@
  * limitations under the License.
  */
 
-export type * from "./ActionDefinition";
-export type * from "./Definition";
+export type {
+  ActionDefinition,
+  ActionModifiedEntity,
+  ActionParameterDefinition,
+  ObjectActionDataType,
+  ObjectSetActionDataType,
+  ValidActionParameterTypes,
+  ValidBaseActionParameterTypes,
+} from "./ActionDefinition";
+export type {
+  LinkDefinition,
+  LinkDefinitionFrom,
+  LinkKeysFrom,
+  LinkTargetTypeFrom,
+  ObjectDefinition,
+  ObjectInfoFrom,
+  ObjectTypesFrom,
+  OntologyDefinition,
+  OsdkObjectLink,
+  OsdkObjectPropertyType,
+  OsdkObjectRawPropertyType,
+  PropertyDefinition,
+  PropertyDefinitionFrom,
+  PropertyDefinitionsFrom,
+  PropertyKeysFrom,
+  ValidPropertyTypes,
+} from "./Definition";
 export type { OntologyMetadata } from "./OntologyMetadata";
 export type { OsdkObject } from "./OsdkObject";
 export type { OsdkObjectFrom } from "./OsdkObjectFrom";
-export type * from "./QueryDefinition";
+export type {
+  AggregationKeyDataType,
+  ObjectQueryDataType,
+  ObjectSetQueryDataType,
+  QueryDataType,
+  QueryDataTypeDefinition,
+  QueryDefinition,
+  QueryParameterDefinition,
+  RangeAggregationKeyDataType,
+  SetQueryDataType,
+  SimpleAggregationKeyDataType,
+  StructQueryDataType,
+  ThreeDimensionalAggregationDataType,
+  ThreeDimensionalQueryAggregationDefinition,
+  TwoDimensionalAggregationDataType,
+  TwoDimensionalQueryAggregationDefinition,
+  UnionQueryDataType,
+  ValidBaseQueryDataTypes,
+} from "./QueryDefinition";

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/generator/src/v1.1/generatePerActionDataFiles.ts
+++ b/packages/generator/src/v1.1/generatePerActionDataFiles.ts
@@ -67,7 +67,9 @@ export async function generatePerActionDataFiles(
   );
 }
 
-function extractReferencedObjectsFromAction(actionType: ActionTypeV2) {
+function extractReferencedObjectsFromAction(
+  actionType: ActionTypeV2,
+): string[] {
   const referencedObjectsInParameters = Object.values(actionType.parameters)
     .flatMap(({ dataType }) => {
       const objectTypeReference = extractReferencedObjectsFromActionParameter(
@@ -94,7 +96,7 @@ function extractReferencedObjectsFromAction(actionType: ActionTypeV2) {
 
 function extractReferencedObjectsFromActionParameter(
   actionParameter: ActionParameterType,
-) {
+): string | undefined {
   switch (actionParameter.type) {
     case "objectSet":
     case "object":

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -49,6 +49,7 @@ describe("generator", () => {
       );
     }
 
+    // TODO: Certain errors are expected since we can't resolve the static code, but we should fix them.
     const errors = diagnostics.filter(q => q.code !== 2792);
     expect(errors).toHaveLength(0);
   });

--- a/packages/generator/tsconfig.json
+++ b/packages/generator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/packages/legacy-client/src/client/objects/convertWireToOsdkObject.ts
+++ b/packages/legacy-client/src/client/objects/convertWireToOsdkObject.ts
@@ -126,7 +126,8 @@ export function convertWireToOsdkObject<
   });
   setPropertyAccessors<T, O>(client, apiName, obj);
 
-  return obj as OsdkLegacyObjectFrom<O, T>;
+  /* this `as unknown` is required for ts4.9 compatability */
+  return obj as unknown as OsdkLegacyObjectFrom<O, T>;
 }
 
 function setPropertyAccessors<

--- a/packages/legacy-client/src/client/ontology.ts
+++ b/packages/legacy-client/src/client/ontology.ts
@@ -38,7 +38,8 @@ export class Ontology<O extends OntologyDefinition<any>> {
   }
 
   get queries(): Queries<O> {
-    return createQueryProxy(this.#client);
+    /* this `as any` is required for ts4.9 compatability */
+    return createQueryProxy(this.#client) as any;
   }
 
   get attachments(): Attachments {

--- a/packages/legacy-client/src/client/queryProxy.ts
+++ b/packages/legacy-client/src/client/queryProxy.ts
@@ -36,13 +36,15 @@ export function createQueryProxy<O extends OntologyDefinition<any>>(
           return async function(
             params: QueryParameters<O, typeof q>,
           ): Promise<WrappedQueryReturnType<O, typeof q>> {
-            return executeQuery(client, q, params);
+            /* this `as any` is required for ts4.9 compatability */
+            return executeQuery(client, q, params) as any;
           };
         } else {
           return async function(): Promise<
             WrappedQueryReturnType<O, typeof q>
           > {
-            return executeQuery(client, q);
+            /* this `as any` is required for ts4.9 compatability */
+            return executeQuery(client, q) as any;
           };
         }
       }

--- a/packages/legacy-client/src/client/utils/index.ts
+++ b/packages/legacy-client/src/client/utils/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export type * from "./IsEmptyRecord";
-export type * from "./ValuesOfMap";
+export type { IsEmptyRecord } from "./IsEmptyRecord";
+export type { ValuesOfMap } from "./ValuesOfMap";

--- a/packages/legacy-client/tsconfig.json
+++ b/packages/legacy-client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/base",
+  "extends": "../../monorepo/tsconfig/tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^18.0.0
         version: 18.17.15
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^4.9.0
+        version: 4.9.5
 
   monorepo/eslint-config-sane:
     dependencies:
@@ -5010,6 +5010,12 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
+    dev: true
+
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
     dev: true
 
   /typescript@5.2.2:


### PR DESCRIPTION
- Change examples/one_dot_one to use ts4.9
- Fix errors coming from api, generator, and legacy-client related to the old compiler