### PR TITLE
Protect against duplicate identifiers across object, query, and action names

### DIFF
--- a/.changeset/popular-snakes-pretend.md
+++ b/.changeset/popular-snakes-pretend.md
@@ -1,0 +1,11 @@
+---
+"@osdk/legacy-client": patch
+"@osdk/examples.one.dot.one": patch
+"@osdk/generator": patch
+"@osdk/gateway": patch
+"@osdk/client": patch
+"@osdk/api": patch
+"@osdk/cli": patch
+---
+
+Handle conflicts between object, action, and query names

--- a/packages/generator/src/util/commaSeparatedIdentifiers.ts
+++ b/packages/generator/src/util/commaSeparatedIdentifiers.ts
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
-export function commaSeparatedIdentifiers(identifiers: ReadonlyArray<string>) {
-  return identifiers.join(",");
+export function commaSeparatedIdentifiers(
+  identifiers: ReadonlyArray<string>,
+  alternateNames?: ReadonlyMap<string, string>,
+) {
+  return identifiers.map(i => {
+    const alt = alternateNames?.get(i);
+    if (alt) {
+      return `${i}: ${alt}`;
+    }
+    return i;
+  }).join(",");
 }

--- a/packages/generator/src/util/commaSeparatedTypeIdentifiers.ts
+++ b/packages/generator/src/util/commaSeparatedTypeIdentifiers.ts
@@ -16,6 +16,9 @@
 
 export function commaSeparatedTypeIdentifiers(
   identifiers: ReadonlyArray<string>,
+  altNames?: ReadonlyMap<string, string>,
 ) {
-  return identifiers.map(i => `${i}: typeof ${i}`).join(",");
+  return identifiers.map(i => `${i}: typeof ${altNames?.get(i) ?? i}`).join(
+    ",",
+  );
 }


### PR DESCRIPTION
Just suffix `Action` or `Query` to make them unique again