### PR TITLE
Fix generated query return type

### DIFF
--- a/.changeset/new-kings-destroy.md
+++ b/.changeset/new-kings-destroy.md
@@ -1,0 +1,12 @@
+---
+"@osdk/legacy-client": patch
+"@osdk/examples.one.dot.one": patch
+"@osdk/generator": patch
+"@osdk/examples.todoapp": patch
+"@osdk/gateway": patch
+"@osdk/client": patch
+"@osdk/api": patch
+"@osdk/cli": patch
+---
+
+Fix query return type for objects


### PR DESCRIPTION
Objects are always hydrated even if the backend returns only a PK in the query response