### PR TITLE
Check generated code for missed deletes

### DIFF
--- a/examples/one_dot_one/package.json
+++ b/examples/one_dot_one/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
-    "codegen": "osdk unstable typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk unstable typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json",
     "dev:transpile": "tsup --watch",
     "fix-lint": "eslint . --fix && dprint fmt --config $(find-up dprint.json)",
     "lint": "eslint . && dprint check  --config $(find-up dprint.json)",

--- a/examples/todoapp/package.json
+++ b/examples/todoapp/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc && vite build",
-    "codegen": "osdk unstable typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json",
+    "codegen": "rm -rf src/generatedNoCheck/* && osdk unstable typescript generate --outDir src/generatedNoCheck --ontologyPath ontology.json",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "codegen": {
-      "inputs": ["ontology.json"],
+      "inputs": ["ontology.json", "@osdk/generator", "@osdk/cli"],
       "outputs": ["src/generatedNoCheck/**/*"],
       "dependsOn": ["^transpile", "^typecheck"]
     },


### PR DESCRIPTION
When the generator or cli changes (or the ontology.json still) we re-run the codegen step. This would mark files as deleted that we no longer generate and forces us to at least have acknowledged the delete in a CR.