### PR TITLE
Allow direct connection to a stack for ontology generation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@osdk/api": "workspace:*",
+    "@osdk/gateway": "workspace:*",
     "@osdk/generator": "workspace:*",
     "@osdk/shared.net": "workspace:*",
     "archiver": "^6.0.1",

--- a/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
@@ -16,7 +16,9 @@
 
 export interface TypescriptGenerateArgs {
   outDir: string;
-  ontologyPath: string;
+  ontologyPath?: string;
+  stack?: string;
+  clientId?: string;
   beta?: boolean;
   packageType: "commonjs" | "module";
 }

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -35,7 +35,22 @@ export const command: CommandModule<
           ontologyPath: {
             description: "path to the ontology wire json",
             type: "string",
-            demandOption: true,
+            demandOption: false,
+            conflicts: ["stack", "clientId"],
+          },
+          stack: {
+            description: "the URL to the stack that contains the ontology",
+            type: "string",
+            demandOption: false,
+            conflicts: "ontologyPath",
+            implies: "clientId",
+          },
+          clientId: {
+            description: "the application's client id",
+            type: "string",
+            demandOption: false,
+            conflicts: "ontologyPath",
+            implies: "stack",
           },
           beta: {
             type: "boolean",
@@ -48,8 +63,19 @@ export const command: CommandModule<
           },
         } as const,
       ).group(
-        ["outDir", "ontologyPath"],
-        "Version To Deploy (requires one of)",
+        ["ontologyPath", "outDir"],
+        "Generate from a local file",
+      ).group(["stack", "clientId", "outDir"], "OR Generate from a stack")
+      .check(
+        (argv) => {
+          if (argv.ontologyPath || argv.stack) {
+            return true;
+          } else {
+            throw new Error(
+              "Error: Must specify either ontologyPath or stack and sdk",
+            );
+          }
+        },
       );
   },
   handler: async (args) => {

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -72,7 +72,7 @@ export const command: CommandModule<
             return true;
           } else {
             throw new Error(
-              "Error: Must specify either ontologyPath or stack and sdk",
+              "Error: Must specify either ontologyPath or stack and clientId",
             );
           }
         },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../api"
     },
     {
+      "path": "../gateway"
+    },
+    {
       "path": "../generator"
     },
     {

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -180,6 +180,7 @@ export class ObjectSetListenerWebsocket<
     if (state) {
       const { subscriptionId, objectSet } = state;
       if (subscriptionId) {
+        state.subscriptionId = undefined;
         this.#subscriptionToRequestId.delete(subscriptionId);
       }
       this.#subscribe(requestId, objectSet);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
+      '@osdk/gateway':
+        specifier: workspace:*
+        version: link:../gateway
       '@osdk/generator':
         specifier: workspace:*
         version: link:../generator


### PR DESCRIPTION
Adds the ability to generate an ontology directly from a given stack, given its stack URL and a clientId.
Users can still generate from a json file if they prefer.