### PR TITLE
Remove crypto.randomUUID usage from subscriptions

### DIFF
--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -57,6 +57,8 @@ export class ObjectSetListenerWebsocket<
     ObjectSetListenerWebsocket<any>
   >();
 
+  static #requestId = 0;
+
   static getInstance<O extends OntologyDefinition<any, any, any>>(
     client: ClientContext<O>,
   ): ObjectSetListenerWebsocket<O> {
@@ -118,7 +120,7 @@ export class ObjectSetListenerWebsocket<
     objectSet: Wire.ObjectSet,
     listener: ObjectSetListener<O, K>,
   ): () => void {
-    const requestId = crypto.randomUUID();
+    const requestId = `${ObjectSetListenerWebsocket.#requestId++}`;
     const expiry = setTimeout(() => {
       this.#expire(requestId);
     }, ONE_DAY_MS);


### PR DESCRIPTION
...  since it doesn't work cleanly in node

// draft since this seems to break the subscription when we just send it an incrementing counter?