### PR TITLE
Basic orderBy syntax for discussion

### DIFF
--- a/packages/client/src/object/fetchPageOrThrow.ts
+++ b/packages/client/src/object/fetchPageOrThrow.ts
@@ -15,8 +15,10 @@
  */
 
 import type {
+  InterfaceDefinitionFrom,
   InterfaceKeysFrom,
   InterfacePropertyKeysFrom,
+  ObjectTypeDefinitionFrom,
   ObjectTypeKeysFrom,
   ObjectTypePropertyKeysFrom,
   OntologyDefinition,
@@ -28,6 +30,7 @@ import type { ClientContext } from "@osdk/shared.net";
 import type { Wire } from "../internal/net/index.js";
 import type { OsdkObjectFrom } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
+import type { OrderByTerm } from "../query/OrderBy.js";
 import type { NOOP } from "../util/NOOP.js";
 import { convertWireToOsdkObjects } from "./convertWireToOsdkObjects.js";
 
@@ -58,6 +61,10 @@ export async function fetchPageOrThrow<
     type: "base",
     objectType,
   },
+  orderByArg?: OrderByTerm<
+    T extends InterfaceKeysFrom<O> ? InterfaceDefinitionFrom<O, T>
+      : ObjectTypeDefinitionFrom<O, T>
+  >[],
 ): Promise<
   PageResult<
     NOOP<

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -27,7 +27,12 @@ import type { FetchPageOrThrowArgs } from "../object/fetchPageOrThrow.js";
 import type { OsdkInterfaceFrom, OsdkObjectFrom } from "../OsdkObjectFrom.js";
 import type { PageResult } from "../PageResult.js";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
-import type { AggregationsResults, WhereClause } from "../query/index.js";
+import type {
+  AggregationsResults,
+  OrderBy,
+  OrderByTerm,
+  WhereClause,
+} from "../query/index.js";
 import type { LinkTypesFrom } from "./LinkTypesFrom.js";
 import type { ObjectSetListener } from "./ObjectSetListener.js";
 
@@ -87,6 +92,13 @@ export interface BaseObjectSet<
     >,
   ) => ObjectSet<O, K>;
 
+  orderBy: (
+    ...terms: OrderByTerm<
+      K extends InterfaceKeysFrom<O> ? InterfaceDefinitionFrom<O, K>
+        : ObjectTypeDefinitionFrom<O, K>
+    >[]
+  ) => ObjectSet<O, K>;
+
   pivotTo: <T extends LinkTypesFrom<O, K>>(
     type: T & string,
     opts?: ObjectSetOptions<O, O["objects"][K]["links"][T]["targetType"]>,
@@ -100,6 +112,10 @@ export interface ObjectSetOptions<
   K extends ObjectTypeKeysFrom<O> | InterfaceKeysFrom<O>,
 > {
   $where?: WhereClause<
+    K extends InterfaceKeysFrom<O> ? InterfaceDefinitionFrom<O, K>
+      : ObjectTypeDefinitionFrom<O, K>
+  >;
+  $orderBy?: OrderBy<
     K extends InterfaceKeysFrom<O> ? InterfaceDefinitionFrom<O, K>
       : ObjectTypeDefinitionFrom<O, K>
   >;

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -83,6 +83,7 @@ export function createObjectSet<
         objectType,
         args ?? {},
         objectSet,
+        opts?.$orderBy,
       ) as any;
     },
 
@@ -96,6 +97,14 @@ export function createObjectSet<
         where: modernToLegacyWhereClause(clause),
       });
     },
+
+    orderBy: (...terms) => {
+      return createObjectSet(objectType, clientCtx, {
+        ...opts,
+        $orderBy: [...opts?.$orderBy ?? [], ...terms],
+      }, objectSet);
+    },
+
     // [Symbol.asyncIterator]: () => {
     //   throw "";
     // },

--- a/packages/client/src/query/OrderBy.ts
+++ b/packages/client/src/query/OrderBy.ts
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-export type * from "./aggregations/AggregatableKeys.js";
-export type * from "./aggregations/AggregationResultsWithGroups.js";
-export type * from "./aggregations/AggregationResultsWithoutGroups.js";
-export type * from "./aggregations/AggregationsClause.js";
-export type * from "./aggregations/AggregationsResults.js";
-export type {
-  AllGroupByValues,
-  GroupByClause,
-} from "./aggregations/GroupByClause.js";
-export type { OrderBy, OrderByTerm } from "./OrderBy.js";
-export type {
-  AndWhereClause,
-  NotWhereClause,
-  OrWhereClause,
-  PossibleWhereClauseFilters,
-  WhereClause,
-} from "./WhereClause.js";
+import type { InterfaceDefinition, ObjectTypeDefinition } from "@osdk/api";
+
+export type OrderByTerm<
+  T extends ObjectTypeDefinition<any, any> | InterfaceDefinition<any, any>,
+> = {
+  field: keyof T["properties"];
+  direction: "asc" | "desc";
+};
+
+export type OrderBy<
+  T extends ObjectTypeDefinition<any, any> | InterfaceDefinition<any, any>,
+> = OrderByTerm<T>[];


### PR DESCRIPTION
Supports this syntax:

```typescript
client.objects.Ticket
        .orderBy({ field: sortField, direction: "asc" }, { field: sortField2, direction: "desc" })
        .fetchPageOrThrow();
        
// OR (user can choose to do either, they're equivalent)

client.objects.Ticket
        .orderBy({ field: sortField, direction: "asc" })
        .orderBy({ field: sortField2, direction: "desc" })
        .fetchPageOrThrow();
```