### PR TITLE
Small CLI cleanups from usability feedback

### DIFF
--- a/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
+++ b/packages/cli/src/commands/typescript/generate/TypescriptGenerateArgs.ts
@@ -17,6 +17,7 @@
 export interface TypescriptGenerateArgs {
   outDir: string;
   ontologyPath?: string;
+  ontologyWritePath?: string;
   stack?: string;
   clientId?: string;
   beta?: boolean;

--- a/packages/cli/src/commands/typescript/generate/generate.ts
+++ b/packages/cli/src/commands/typescript/generate/generate.ts
@@ -52,6 +52,12 @@ export const command: CommandModule<
             conflicts: "ontologyPath",
             implies: "stack",
           },
+          ontologyWritePath: {
+            description: "path to write the ontology wire json",
+            type: "string",
+            demandOption: false,
+            conflicts: ["ontologyPath"],
+          },
           beta: {
             type: "boolean",
             description: "Should generate beta sdk",
@@ -65,7 +71,10 @@ export const command: CommandModule<
       ).group(
         ["ontologyPath", "outDir"],
         "Generate from a local file",
-      ).group(["stack", "clientId", "outDir"], "OR Generate from a stack")
+      ).group(
+        ["stack", "clientId", "outDir", "ontologyWritePath"],
+        "OR Generate from a stack",
+      )
       .check(
         (argv) => {
           if (argv.ontologyPath || argv.stack) {

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -49,7 +49,9 @@ async function generateFromLocalFile(args: TypescriptGenerateArgs) {
 }
 
 async function generateFromStack(args: TypescriptGenerateArgs) {
-  const { stack, clientId } = args as { stack: string; clientId: string };
+  const { stack, clientId, ontologyWritePath } = args as
+    & TypescriptGenerateArgs
+    & { stack: string; clientId: string };
 
   const token = await invokeLoginFlow({
     applicationId: clientId,
@@ -81,6 +83,10 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
       createOpenApiRequest(stack, fetch),
       ontologies.data[0].apiName,
     );
+
+    if (ontologyWritePath) {
+      fs.writeFileSync(ontologyWritePath, JSON.stringify(ontology, null, 2));
+    }
 
     await generateClientSdk(ontology, args);
   } catch (e) {


### PR DESCRIPTION
- The code generation command now optionally writes the json to disk for hand-modification
- The CLI will now detect if the authentication process is taking too long and prompt the user with the URL
- If the ontology fetch fails, we prompt with the underlying reason if one exists, like for invalid cert