### PR TITLE
Block osdk generation into directories that have contents

### DIFF
--- a/.changeset/hot-otters-cheat.md
+++ b/.changeset/hot-otters-cheat.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator": patch
+"@osdk/cli": patch
+---
+
+Block OSDK generation into directories that don't exist or are empty

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -26,6 +26,7 @@ import {
 import { createClientContext, createOpenApiRequest } from "@osdk/shared.net";
 import { consola } from "consola";
 import * as fs from "node:fs";
+import type {} from "@osdk/generator../../../../../generator/src/MinimalFs.js";
 import invokeLoginFlow from "../../auth/login/loginFlow.js";
 import type { TypescriptGenerateArgs } from "./TypescriptGenerateArgs.js";
 
@@ -98,31 +99,27 @@ async function generateClientSdk(
   ontology: WireOntologyDefinition,
   args: TypescriptGenerateArgs,
 ) {
+  const minimalFs = {
+    writeFile: (path: string, contents: string) => {
+      return fs.promises.writeFile(path, contents, "utf-8");
+    },
+    mkdir: async (path: string, options?: { recursive: boolean }) => {
+      await fs.promises.mkdir(path, options);
+    },
+    readdir: async (path: string) => fs.promises.readdir(path),
+  };
+
   if (args.beta) {
     await generateClientSdkVersionTwoPointZero(
       ontology,
-      {
-        writeFile: (path, contents) => {
-          return fs.promises.writeFile(path, contents, "utf-8");
-        },
-        mkdir: async (path, options) => {
-          await fs.promises.mkdir(path, options);
-        },
-      },
+      minimalFs,
       args.outDir,
       args.packageType,
     );
   } else {
     await generateClientSdkVersionOneDotOne(
       ontology,
-      {
-        writeFile: (path, contents) => {
-          return fs.promises.writeFile(path, contents, "utf-8");
-        },
-        mkdir: async (path, options) => {
-          await fs.promises.mkdir(path, options);
-        },
-      },
+      minimalFs,
       args.outDir,
       args.packageType,
     );

--- a/packages/generator/src/MinimalFs.ts
+++ b/packages/generator/src/MinimalFs.ts
@@ -17,6 +17,8 @@
 export interface MinimalFs {
   mkdir: (path: string, options?: { recursive: boolean }) => Promise<void>;
   writeFile: WriteFileFn;
+  readdir: ReaddirFn;
 }
 
 export type WriteFileFn = (path: string, contents: string) => Promise<void>;
+export type ReaddirFn = (path: string) => Promise<string[]>;

--- a/packages/generator/src/util/InMemoryFs.ts
+++ b/packages/generator/src/util/InMemoryFs.ts
@@ -30,5 +30,8 @@ export function createInMemoryFs(): InMemoryFs {
     },
     getFiles: () => files,
     getFile: (path) => files[path],
+    readdir: async (path) => {
+      throw new Error("not implemented");
+    },
   };
 }

--- a/packages/generator/src/util/test/createMockMinimalFiles.ts
+++ b/packages/generator/src/util/test/createMockMinimalFiles.ts
@@ -15,7 +15,7 @@
  */
 
 import { vi } from "vitest";
-import type { WriteFileFn } from "../../MinimalFs";
+import type { ReaddirFn, WriteFileFn } from "../../MinimalFs";
 
 export function createMockMinimalFiles() {
   const writeFile = vi.fn<Parameters<WriteFileFn>, ReturnType<WriteFileFn>>(
@@ -23,10 +23,16 @@ export function createMockMinimalFiles() {
   );
   const getFiles = () => Object.fromEntries(writeFile.mock.calls);
 
+  const readdir = vi.fn<
+    Parameters<ReaddirFn>,
+    ReturnType<ReaddirFn>
+  >(() => Promise.resolve([]));
+
   return {
     minimalFiles: {
       writeFile: writeFile as WriteFileFn,
       mkdir: () => Promise.resolve(),
+      readdir: readdir as ReaddirFn,
     },
     getFiles,
     dumpFilesToConsole: () => {

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -17,6 +17,7 @@
 import * as path from "node:path";
 import type { MinimalFs } from "../MinimalFs";
 import { sanitizeMetadata } from "../shared/sanitizeMetadata";
+import { verifyOutdir } from "../util/verifyOutdir";
 import type { WireOntologyDefinition } from "../WireOntologyDefinition";
 import { generateActions } from "./generateActions";
 import { generateBackCompatDeprecatedExports } from "./generateBackCompatDeprecatedExports";
@@ -41,6 +42,8 @@ export async function generateClientSdkVersionOneDotOne(
   const objectsDir = path.join(outDir, "ontology", "objects");
   const actionsDir = path.join(outDir, "ontology", "actions");
   const queriesDir = path.join(outDir, "ontology", "queries");
+
+  verifyOutdir(outDir, fs);
 
   const sanitizedOntology = sanitizeMetadata(ontology);
   await generateFoundryClientFile(fs, outDir, importExt);

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { mkdir, rmdir, writeFile } from "fs/promises";
-import { describe, expect, test } from "vitest";
+import { mkdir, readdir, rmdir, writeFile } from "fs/promises";
+import { describe, expect, test, vi } from "vitest";
 import { compileThis } from "../util/test/compileThis";
 import { createMockMinimalFiles } from "../util/test/createMockMinimalFiles";
 import { TodoWireOntology } from "../util/test/TodoWireOntology";
@@ -54,6 +54,21 @@ describe("generator", () => {
     expect(errors).toHaveLength(0);
   });
 
+  test("throws an error when target destination is not empty", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+
+    helper.minimalFiles.readdir = vi.fn(async (_path: string) => ["file"]);
+
+    expect(async () => {
+      await expect(generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        helper.minimalFiles,
+        BASE_PATH,
+      )).rejects.toThrow();
+    });
+  });
+
   test.skip("runs generator locally", async () => {
     try {
       await rmdir(`${__dirname}/generated`, { recursive: true });
@@ -69,6 +84,7 @@ describe("generator", () => {
         mkdir: async (path, options) => {
           await mkdir(path, options);
         },
+        readdir: async (path) => await readdir(path),
       },
       `${__dirname}/generated/`,
     );

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -20,6 +20,7 @@ import { sanitizeMetadata } from "../shared/sanitizeMetadata";
 import { __UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst } from "../shared/UNSTABLE_wireInterfaceTypeV2ToSdkObjectConst";
 import { wireObjectTypeV2ToSdkObjectConst } from "../shared/wireObjectTypeV2ToSdkObjectConst";
 import { formatTs } from "../util/test/formatTs";
+import { verifyOutdir } from "../util/verifyOutdir";
 import { generatePerActionDataFiles } from "../v1.1/generatePerActionDataFiles";
 import type { __UNSTABLE_WireOntologyDefinitionV2 } from "../WireOntologyDefinition";
 import { generateOntologyMetadataFile } from "./generateMetadata";
@@ -30,6 +31,8 @@ export async function generateClientSdkVersionTwoPointZero(
   outDir: string,
   packageType: "module" | "commonjs" = "commonjs",
 ) {
+  verifyOutdir(outDir, fs);
+
   const sanitizedOntology = sanitizeMetadata(ontology);
 
   const objectNames = Object.keys(sanitizedOntology.objectTypes);


### PR DESCRIPTION
This prevents us from users generating their .tgz packages on their local machine and combining multiple runs worth of output into a single (broken) package.