### PR TITLE
Alphabetize property names in generated object definition files

### DIFF
--- a/.changeset/twelve-needles-kneel.md
+++ b/.changeset/twelve-needles-kneel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+Alphabetize property names when generating object definitions

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/objects/ObjectTypeWithAllPropertyTypes.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinition } from '@osdk/api';
+import type { ObjectTypeDefinition } from '@osdk/api';
 import type {
   Attachment,
   GeoPoint,
@@ -15,36 +15,36 @@ import type {
 export interface ObjectTypeWithAllPropertyTypes extends OntologyObject {
   readonly __apiName: 'ObjectTypeWithAllPropertyTypes';
   readonly __primaryKey: number;
-  readonly id: number | undefined;
-  readonly string: string | undefined;
-  readonly boolean: boolean | undefined;
-  readonly date: LocalDate | undefined;
-  readonly dateTime: Timestamp | undefined;
-  readonly decimal: number | undefined;
-  readonly integer: number | undefined;
-  readonly long: number | undefined;
-  readonly short: number | undefined;
-  readonly float: number | undefined;
-  readonly double: number | undefined;
-  readonly byte: number | undefined;
   readonly attachment: Attachment | undefined;
-  readonly geoPoint: GeoPoint | undefined;
-  readonly geoShape: GeoShape | undefined;
-  readonly stringArray: string[] | undefined;
-  readonly booleanArray: boolean[] | undefined;
-  readonly dateArray: LocalDate[] | undefined;
-  readonly dateTimeArray: Timestamp[] | undefined;
-  readonly decimalArray: number[] | undefined;
-  readonly integerArray: number[] | undefined;
-  readonly longArray: number[] | undefined;
-  readonly shortArray: number[] | undefined;
-  readonly floatArray: number[] | undefined;
-  readonly doubleArray: number[] | undefined;
-  readonly byteArray: number[] | undefined;
   readonly attachmentArray: Attachment[] | undefined;
+  readonly boolean: boolean | undefined;
+  readonly booleanArray: boolean[] | undefined;
+  readonly byte: number | undefined;
+  readonly byteArray: number[] | undefined;
+  readonly date: LocalDate | undefined;
+  readonly dateArray: LocalDate[] | undefined;
+  readonly dateTime: Timestamp | undefined;
+  readonly dateTimeArray: Timestamp[] | undefined;
+  readonly decimal: number | undefined;
+  readonly decimalArray: number[] | undefined;
+  readonly double: number | undefined;
+  readonly doubleArray: number[] | undefined;
+  readonly float: number | undefined;
+  readonly floatArray: number[] | undefined;
+  readonly geoPoint: GeoPoint | undefined;
   readonly geoPointArray: GeoPoint[] | undefined;
+  readonly geoShape: GeoShape | undefined;
   readonly geoShapeArray: GeoShape[] | undefined;
+  readonly id: number | undefined;
+  readonly integer: number | undefined;
+  readonly integerArray: number[] | undefined;
+  readonly long: number | undefined;
+  readonly longArray: number[] | undefined;
   readonly numericTimeseries: TimeSeries<number> | undefined;
+  readonly short: number | undefined;
+  readonly shortArray: number[] | undefined;
+  readonly string: string | undefined;
+  readonly stringArray: string[] | undefined;
   readonly stringTimeseries: TimeSeries<string> | undefined;
 }
 

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Person.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Person.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinition } from '@osdk/api';
+import type { ObjectTypeDefinition } from '@osdk/api';
 import type { MultiLink, OntologyObject } from '@osdk/legacy-client';
 import type { Todo } from './Todo';
 

--- a/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples/one_dot_one/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinition } from '@osdk/api';
+import type { ObjectTypeDefinition } from '@osdk/api';
 import type { OntologyObject, SingleLink } from '@osdk/legacy-client';
 import type { Person } from './Person';
 
@@ -8,12 +8,12 @@ import type { Person } from './Person';
 export interface Todo extends OntologyObject {
   readonly __apiName: 'Todo';
   readonly __primaryKey: number;
-  readonly id: number | undefined;
   /**
    * The text of the todo
    */
   readonly body: string | undefined;
   readonly complete: boolean | undefined;
+  readonly id: number | undefined;
   readonly Assignee: SingleLink<Person>;
 }
 

--- a/examples/todoapp/src/generatedNoCheck/ontology/objects/Todo.ts
+++ b/examples/todoapp/src/generatedNoCheck/ontology/objects/Todo.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDefinition } from '@osdk/api';
+import type { ObjectTypeDefinition } from '@osdk/api';
 import type { OntologyObject } from '@osdk/legacy-client';
 
 /**
@@ -8,11 +8,11 @@ export interface Todo extends OntologyObject {
   readonly __apiName: 'Todo';
   readonly __primaryKey: string;
   readonly id: string | undefined;
+  readonly isComplete: boolean | undefined;
   /**
    * The text of the todo
    */
   readonly title: string | undefined;
-  readonly isComplete: boolean | undefined;
 }
 
 export const Todo = {

--- a/packages/generator/src/v1.1/generatePerObjectInterfaceAndDataFiles.ts
+++ b/packages/generator/src/v1.1/generatePerObjectInterfaceAndDataFiles.ts
@@ -35,7 +35,7 @@ export async function generatePerObjectInterfaceAndDataFiles(
       await fs.writeFile(
         path.join(outDir, `${object.objectType.apiName}.ts`),
         await formatTs(`
-        import { ObjectTypeDefinition } from "@osdk/api";
+        import type { ObjectTypeDefinition } from "@osdk/api";
         ${
           wireObjectTypeV2ToObjectInterfaceStringV1(
             object,

--- a/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.test.ts
+++ b/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.test.ts
@@ -36,12 +36,12 @@ describe("wireObjectTypeV2ToObjectInterfaceStringV1", () => {
       export interface Todo extends OntologyObject {
         readonly __apiName: 'Todo';
         readonly __primaryKey: number;
-        readonly id: number | undefined;
         /**
          * The text of the todo
          */
         readonly body: string | undefined;
         readonly complete: boolean | undefined;
+        readonly id: number | undefined;
         readonly Assignee: SingleLink<Person>;
       }
       "

--- a/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.ts
+++ b/packages/generator/src/v1.1/wireObjectTypeV2ToV1ObjectInterfaceString.ts
@@ -46,7 +46,9 @@ ${
     )
   };
 ${
-    Object.entries(objectTypeWithLinks.objectType.properties).flatMap((
+    Object.entries(objectTypeWithLinks.objectType.properties).sort((a, b) =>
+      a[0].localeCompare(b[0])
+    ).flatMap((
       [propertyName, propertyDefinition],
     ) => {
       const propertyType = wirePropertyTypeV2ToTypeScriptType(

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToObjectDefinitionInterfaceString.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToObjectDefinitionInterfaceString.ts
@@ -24,7 +24,8 @@ export function wireObjectTypeV2ToObjectDefinitionInterfaceString(
       apiName: "${input.apiName}";
       properties: {
         ${
-    Object.entries(input.properties).map(([key, value]) => `
+    Object.entries(input.properties).sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([key, value]) => `
       /**
        * ${value.description ?? ""}
        **/


### PR DESCRIPTION
This should help us more quickly find if properties are included in an object or not when reading the generated source code.