### PR TITLE
Add objects, actions, queries enumerability for backcompat

### DIFF
--- a/.changeset/cold-carrots-dream.md
+++ b/.changeset/cold-carrots-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Ensure that ontology objects actions and queries have enumerable keys

--- a/packages/legacy-client/src/client/actions/actions.test.ts
+++ b/packages/legacy-client/src/client/actions/actions.test.ts
@@ -259,4 +259,15 @@ describe("Actions", () => {
 
     assert(actionResponse.type === "ok");
   });
+
+  it("has an enumerable list of actions", () => {
+    const actionProxy = createActionProxy(client);
+    expect(Object.getOwnPropertyNames(actionProxy)).toMatchInlineSnapshot(`
+      [
+        "createTask",
+        "createTodo",
+        "updateTask",
+      ]
+    `);
+  });
 });

--- a/packages/legacy-client/src/client/actions/createActionProxy.ts
+++ b/packages/legacy-client/src/client/actions/createActionProxy.ts
@@ -23,7 +23,7 @@ import type { ActionArgs, Actions, WrappedActionReturnType } from "./actions";
 export function createActionProxy<
   O extends OntologyDefinition<any>,
 >(client: ClientContext<O>): Actions<O> {
-  return new Proxy(
+  const proxy = new Proxy(
     {},
     {
       get: (_target, p: keyof O["actions"], _receiver) => {
@@ -51,6 +51,19 @@ export function createActionProxy<
 
         return undefined;
       },
+      ownKeys(_target) {
+        return Object.keys(client.ontology.actions);
+      },
+      getOwnPropertyDescriptor(_target, p) {
+        if (typeof p === "string") {
+          return {
+            enumerable: client.ontology.actions[p] != null,
+            configurable: true,
+            value: proxy[p],
+          };
+        }
+      },
     },
   ) as Actions<O>;
+  return proxy;
 }

--- a/packages/legacy-client/src/client/ontology.test.ts
+++ b/packages/legacy-client/src/client/ontology.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClientContext } from "@osdk/shared.net";
+import { createClientContext } from "@osdk/shared.net";
+import { MOCK_ORIGIN, MockOntology } from "@osdk/shared.test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createObjectSetCreator } from "./ontology";
+
+describe(createObjectSetCreator, () => {
+  let client: ClientContext<MockOntology>;
+
+  beforeEach(() => {
+    try {
+      client = createClientContext(
+        MockOntology,
+        MOCK_ORIGIN,
+        () => "Token",
+        undefined,
+        fetch,
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  it("has an enumerable list of object types", () => {
+    const objectSetCreator = createObjectSetCreator(client);
+    expect(Object.getOwnPropertyNames(objectSetCreator)).toMatchInlineSnapshot(`
+      [
+        "Task",
+        "Todo",
+        "ObjectTypeWithAllPropertyTypes",
+        "ObjectTypeWithReservedNames",
+      ]
+    `);
+  });
+});

--- a/packages/legacy-client/src/client/ontology.ts
+++ b/packages/legacy-client/src/client/ontology.ts
@@ -51,7 +51,7 @@ export class Ontology<O extends OntologyDefinition<any>> {
 export function createObjectSetCreator<
   O extends OntologyDefinition<any>,
 >(client: ClientContext<O>): Objects<O> {
-  return new Proxy(
+  const proxy = new Proxy(
     {},
     {
       get: (_target, p, _receiver) => {
@@ -61,6 +61,20 @@ export function createObjectSetCreator<
 
         return undefined;
       },
+      ownKeys(_target) {
+        return Object.keys(client.ontology.objects);
+      },
+      getOwnPropertyDescriptor(_target, p) {
+        if (typeof p === "string") {
+          return {
+            enumerable: client.ontology.objects[p] != null,
+            configurable: true,
+            value: proxy[p],
+          };
+        }
+      },
     },
   ) as Objects<O>;
+
+  return proxy;
 }

--- a/packages/legacy-client/src/client/queries.test.ts
+++ b/packages/legacy-client/src/client/queries.test.ts
@@ -334,4 +334,16 @@ describe("Queries", () => {
       }]>();
     });
   });
+
+  it("has an enumerable list of queries", () => {
+    const queryProxy = createQueryProxy(client);
+    expect(Object.getOwnPropertyNames(queryProxy)).toMatchInlineSnapshot(`
+      [
+        "queryTakesNoParameters",
+        "queryReturnsAggregation",
+        "queryTakesAllParameterTypes",
+        "queryTakesNestedObjects",
+      ]
+    `);
+  });
 });

--- a/packages/legacy-client/src/client/queryProxy.ts
+++ b/packages/legacy-client/src/client/queryProxy.ts
@@ -27,7 +27,7 @@ import type {
 export function createQueryProxy<O extends OntologyDefinition<any>>(
   client: ClientContext<O>,
 ): Queries<O> {
-  return new Proxy({}, {
+  const proxy = new Proxy({}, {
     get(_target, q: QueryNamesFrom<O> & string, _receiver) {
       const queryDefinition = client.ontology.queries[q];
       if (queryDefinition) {
@@ -52,5 +52,19 @@ export function createQueryProxy<O extends OntologyDefinition<any>>(
 
       return undefined;
     },
+    ownKeys(_target) {
+      return Object.keys(client.ontology.queries);
+    },
+    getOwnPropertyDescriptor(_target, p) {
+      if (typeof p === "string") {
+        return {
+          enumerable: client.ontology.queries[p] != null,
+          configurable: true,
+          value: proxy[p],
+        };
+      }
+    },
   }) as Queries<O>;
+
+  return proxy;
 }


### PR DESCRIPTION
When we moved to the proxy-based implementation with v1.1 it accidentally removed the ability for us to inspect what types that we had compiled in.