### PR TITLE
Fix incorrect order of exports in generated package.json

### DIFF
--- a/.changeset/ninety-guests-shake.md
+++ b/.changeset/ninety-guests-shake.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Fix generated package.json to have default export at the end to prevent runtime errors

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackageJson.ts
@@ -23,6 +23,7 @@ export async function generatePackageJson(options: {
   packagePath: string;
   dependencies?: Array<{ dependencyName: string; dependencyVersion: string }>;
 }) {
+  // Note that any "default" conditions _must_ be last in their block otherwise it will crash at runtime
   const packageJson = {
     name: options.packageName,
     version: options.packageVersion,
@@ -31,11 +32,11 @@ export async function generatePackageJson(options: {
     exports: {
       ".": {
         types: "./index.d.ts",
-        default: "./index.js",
         script: {
           types: "./dist/bundle/index.d.ts",
           default: "./dist/bundle/index.esm.js",
         },
+        default: "./index.js",
       },
       "./ontology/objects": {
         types: "./ontology/objects/index.d.ts",


### PR DESCRIPTION
This was causing errors of the flavor:

```
ERROR in ./src/pages/home.tsx 4:0-61
Module not found: Error: Default condition should be last one
 @ ./src/app.tsx 4:0-40 16:45-53

ERROR in ./src/utils/client.ts 2:0-69
Module not found: Error: Default condition should be last one
 @ ./src/pages/authCallback.tsx 4:0-41 13:8-14:19
 @ ./src/app.tsx 5:0-52 27:37-49

webpack 5.82.1 compiled with 2 errors in 1939 ms
```