### PR TITLE
Remove ObjectSetOptions

### DIFF
--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -20,7 +20,7 @@ import type {
   OntologyDefinition,
 } from "@osdk/api";
 import type { Actions } from "./actions/Actions.js";
-import type { ObjectSet, ObjectSetOptions } from "./objectSet/ObjectSet.js";
+import type { ObjectSet } from "./objectSet/ObjectSet.js";
 import type { ObjectSetCreator } from "./ObjectSetCreator.js";
 
 export type ConcreteObjectType<
@@ -31,7 +31,6 @@ export type ConcreteObjectType<
 export interface Client<O extends OntologyDefinition<any>> {
   objectSet: <const K extends ObjectOrInterfaceKeysFrom<O>>(
     type: K,
-    opts?: ObjectSetOptions<O, K>,
   ) => ObjectSet<O, K>;
 
   objects: ObjectSetCreator<O>;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -36,8 +36,8 @@ export function createClient<O extends OntologyDefinition<any>>(
     fetchFn,
   );
 
-  const objectSetFactory: ObjectSetFactory<O> = (type, opts) =>
-    createObjectSet(type, clientCtx, opts);
+  const objectSetFactory: ObjectSetFactory<O> = (type) =>
+    createObjectSet(type, clientCtx);
 
   const client: Client<O> = Object.defineProperties(
     {} as Client<O>,
@@ -53,7 +53,7 @@ export function createClient<O extends OntologyDefinition<any>>(
           objectType: K,
           rid: string,
         ) => {
-          return createObjectSet(objectType as K & string, clientCtx, {}, {
+          return createObjectSet(objectType as K & string, clientCtx, {
             type: "intersect",
             objectSets: [
               {

--- a/packages/client/src/objectSet/ObjectSet.ts
+++ b/packages/client/src/objectSet/ObjectSet.ts
@@ -83,22 +83,13 @@ export interface BaseObjectSet<
 
   pivotTo: <T extends LinkTypesFrom<O, K>>(
     type: T & string,
-    opts?: ObjectSetOptions<O, O["objects"][K]["links"][T]["targetType"]>,
   ) => ObjectSet<O, O["objects"][K]["links"][T]["targetType"]>;
 
   subscribe: (listener: ObjectSetListener<O, K>) => () => void;
-}
-
-export interface ObjectSetOptions<
-  O extends OntologyDefinition<any>,
-  K extends ObjectOrInterfaceKeysFrom<O>,
-> {
-  $where?: WhereClause<ObjectOrInterfaceDefinitionFrom<O, K>>;
 }
 
 export type ObjectSetFactory<O extends OntologyDefinition<any>> = <
   K extends ObjectOrInterfaceKeysFrom<O>,
 >(
   type: K & string,
-  opts?: ObjectSetOptions<O, K>,
 ) => ObjectSet<O, K>; // FIXME

--- a/packages/client/src/objectSet/createObjectSet.ts
+++ b/packages/client/src/objectSet/createObjectSet.ts
@@ -27,11 +27,7 @@ import { aggregateOrThrow, fetchPageOrThrow } from "../object/index.js";
 import type { AggregateOpts } from "../query/aggregations/AggregateOpts.js";
 import type { AggregationClause, AggregationsResults } from "../query/index.js";
 import type { LinkTypesFrom } from "./LinkTypesFrom.js";
-import type {
-  BaseObjectSet,
-  ObjectSet,
-  ObjectSetOptions,
-} from "./ObjectSet.js";
+import type { BaseObjectSet, ObjectSet } from "./ObjectSet.js";
 import { ObjectSetListenerWebsocket } from "./ObjectSetListenerWebsocket.js";
 
 const searchAroundPrefix = "searchAround_";
@@ -41,7 +37,6 @@ export function createObjectSet<
 >(
   objectType: K & string,
   clientCtx: ClientContext<O>,
-  opts: ObjectSetOptions<O, K> | undefined,
   objectSet: Wire.ObjectSet = {
     type: "base",
     objectType,
@@ -89,7 +84,7 @@ export function createObjectSet<
     //   throw "";
     // },
     where: (clause) => {
-      return createObjectSet(objectType, clientCtx, opts, {
+      return createObjectSet(objectType, clientCtx, {
         type: "filter",
         objectSet: objectSet,
         where: modernToLegacyWhereClause(clause),
@@ -101,9 +96,8 @@ export function createObjectSet<
 
     pivotTo: function<T extends LinkTypesFrom<O, K>>(
       type: T & string,
-      opts?: ObjectSetOptions<O, O["objects"][K]["links"][T]["targetType"]>,
     ): ObjectSet<O, O["objects"][K]["links"][T]["targetType"]> {
-      return createSearchAround(type)().where(opts?.$where ?? {});
+      return createSearchAround(type)();
     },
 
     subscribe(listener) {
@@ -117,7 +111,6 @@ export function createObjectSet<
       return createObjectSet(
         objectType,
         clientCtx,
-        {},
         {
           type: "searchAround",
           objectSet,


### PR DESCRIPTION
This syntax was possible to write, but was not correctly implemented.
```typescript
client.objectSet("Employee", {$where: {"employeeId": 12}})
```

Removing for clarity around how to create filtering object sets.