### PR TITLE
Add Attachments class to v2

### DIFF
--- a/packages/client/src/Definitions.ts
+++ b/packages/client/src/Definitions.ts
@@ -20,6 +20,7 @@ import type {
   OntologyDefinition,
   WirePropertyTypes,
 } from "@osdk/api";
+import type { Attachment } from "./object/Attachment.js";
 
 type MaybeArray<T extends { multiplicity?: boolean | undefined }, U> =
   T["multiplicity"] extends true ? Array<U> : U;
@@ -31,8 +32,12 @@ type MaybeNullable<T extends ObjectTypePropertyDefinition, U> =
 type Raw<T> = T extends Array<any> ? T[0] : T;
 type Converted<T> = T extends Array<any> ? T[1] : T;
 
+// certain data types must be converted at hydration time
+type HydrationConversions<T extends ObjectTypePropertyDefinition> =
+  T["type"] extends "attachment" ? Attachment : WirePropertyTypes[T["type"]];
+
 export type OsdkObjectPropertyType<T extends ObjectTypePropertyDefinition> =
-  MaybeNullable<T, MaybeArray<T, Converted<WirePropertyTypes[T["type"]]>>>;
+  MaybeNullable<T, MaybeArray<T, Converted<HydrationConversions<T>>>>;
 
 export type OsdkObjectRawPropertyType<T extends ObjectTypePropertyDefinition> =
   MaybeNullable<T, MaybeArray<T, Raw<WirePropertyTypes[T["type"]]>>>;

--- a/packages/client/src/object/Attachment.ts
+++ b/packages/client/src/object/Attachment.ts
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-import type { ListObjectsResponseV2 } from "@osdk/gateway/types";
+export interface Attachment {
+  rid: string;
+}
 
-import {
-  employee1,
-  employee2,
-  employee3,
-  objectWithAllPropertyTypes1,
-  objectWithAllPropertyTypesEmptyEntries,
-} from "./objects";
+export class Attachment implements Attachment {
+  constructor(public rid: string) {}
+}
 
-export const loadRequestHandlersV2: {
-  [objectTypeApiName: string]: ListObjectsResponseV2["data"];
-} = {
-  Employee: [employee1, employee2, employee3],
-  objectTypeWithAllPropertyTypes: [
-    objectWithAllPropertyTypes1,
-    objectWithAllPropertyTypesEmptyEntries,
-  ],
-};
+export function isAttachment(o: any): o is Attachment {
+  return o instanceof Attachment;
+}

--- a/packages/client/src/object/ObjectDefinitions.test.ts
+++ b/packages/client/src/object/ObjectDefinitions.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type { OsdkObjectPropertyType } from "../Definitions.js";
+import type { Attachment } from "./Attachment.js";
+
+describe("Object definitions", () => {
+  it("correctly upgrades attachment types at conversion time", () => {
+    const attachment = {
+      type: "attachment",
+    } as const;
+
+    const attachmentArray = {
+      type: "attachment",
+      multiplicity: true,
+    } as const;
+
+    expectTypeOf<OsdkObjectPropertyType<typeof attachment>>().toEqualTypeOf<
+      Attachment
+    >();
+
+    expectTypeOf<OsdkObjectPropertyType<typeof attachmentArray>>()
+      .toEqualTypeOf<
+        Attachment[]
+      >();
+  });
+});

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { apiServer } from "@osdk/shared.test";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Client } from "../Client.js";
+import { createClient } from "../createClient.js";
+import { Ontology as MockOntology } from "../generatedNoCheck/index.js";
+import { Attachment } from "./Attachment.js";
+
+describe("convertWireToOsdkObjects", () => {
+  let client: Client<typeof MockOntology>;
+
+  beforeAll(async () => {
+    apiServer.listen();
+    client = createClient(
+      MockOntology,
+      "https://stack.palantir.com",
+      () => "myAccessToken",
+    );
+  });
+
+  afterAll(() => {
+    apiServer.close();
+  });
+
+  it("reuses the object prototype across objects", async () => {
+    const employees = await client.objects.Employee.fetchPageOrThrow();
+    expect(employees.data.length).toBeGreaterThanOrEqual(2);
+    const [a, b] = employees.data;
+    expect(Object.getPrototypeOf(a)).toBe(Object.getPrototypeOf(b));
+  });
+
+  it("converts attachments as expected", async () => {
+    const withValues = await client.objects.objectTypeWithAllPropertyTypes
+      .where({ id: 1 })
+      .fetchPageOrThrow();
+    expect(withValues.data.length).toBeGreaterThanOrEqual(1);
+
+    const { attachment, attachmentArray } = withValues.data[0];
+
+    expect(attachment).toBeInstanceOf(Attachment);
+    expect(Array.isArray(attachmentArray)).toBeTruthy();
+    expect(attachmentArray![0]).toBeInstanceOf(Attachment);
+
+    const withoutValues = await client.objects.objectTypeWithAllPropertyTypes
+      .where({ id: 2 }).fetchPageOrThrow();
+    const {
+      attachment: emptyAttachment,
+      attachmentArray: emptyAttachmentArray,
+    } = withoutValues.data[0];
+    expect(emptyAttachment).toBeUndefined();
+    expect(emptyAttachmentArray).toBeUndefined();
+  });
+});

--- a/packages/shared.test/src/stubs/objectSetRequest.ts
+++ b/packages/shared.test/src/stubs/objectSetRequest.ts
@@ -19,7 +19,14 @@ import type {
   LoadObjectSetResponseV2,
 } from "@osdk/gateway/types";
 import stableStringify from "json-stable-stringify";
-import { employee1, employee2, employee3, nycOffice } from "./objects";
+import {
+  employee1,
+  employee2,
+  employee3,
+  nycOffice,
+  objectWithAllPropertyTypes1,
+  objectWithAllPropertyTypesEmptyEntries,
+} from "./objects";
 import { employeeObjectType, officeObjectType } from "./objectTypes";
 
 const baseObjectSet: LoadObjectSetRequestV2 = {
@@ -315,6 +322,30 @@ const searchAroundFilteredObjectSet: LoadObjectSetRequestV2 = {
   select: [],
 };
 
+const objectWithAllPropertyTypes: LoadObjectSetRequestV2 = {
+  objectSet: {
+    type: "filter",
+    objectSet: {
+      type: "base",
+      objectType: "objectTypeWithAllPropertyTypes",
+    },
+    where: { type: "eq", field: "id", value: 1 },
+  },
+  "select": [],
+};
+
+const emptyObjectWithAllPropertyTypes: LoadObjectSetRequestV2 = {
+  objectSet: {
+    type: "filter",
+    objectSet: {
+      type: "base",
+      objectType: "objectTypeWithAllPropertyTypes",
+    },
+    where: { type: "eq", field: "id", value: 2 },
+  },
+  "select": [],
+};
+
 export const loadObjectSetRequestHandlers: {
   [key: string]: LoadObjectSetResponseV2["data"];
 } = {
@@ -336,4 +367,8 @@ export const loadObjectSetRequestHandlers: {
   [stableStringify(searchAroundObjectSet)]: [nycOffice],
   [stableStringify(searchAroundFilteredObjectSet)]: [nycOffice],
   [stableStringify(baseObjectSetSelect)]: [employee1, employee2, employee3],
+  [stableStringify(objectWithAllPropertyTypes)]: [objectWithAllPropertyTypes1],
+  [stableStringify(emptyObjectWithAllPropertyTypes)]: [
+    objectWithAllPropertyTypesEmptyEntries,
+  ],
 };

--- a/packages/shared.test/src/stubs/objects.ts
+++ b/packages/shared.test/src/stubs/objects.ts
@@ -97,6 +97,16 @@ export const objectWithAllPropertyTypes1 = {
   attachment2: {
     rid: "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a80",
   },
+  attachmentArray: [
+    {
+      rid:
+        "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a75",
+    },
+    {
+      rid:
+        "ri.attachments.main.attachment.86016861-707f-4292-b258-6a7108915a80",
+    },
+  ],
   long: 1,
   short: 1,
   float: 1.1,


### PR DESCRIPTION
In order to be able to serialize Attachments for Actions, we need to be able to differentiate them when we convert to the wire spec. `{rid: string}` is probably not specific enough to safely create these payloads so we promote it to a full class instead.

legacy-client also added additional methods on the Attachments class to get metadata and then the actual data itself, but that is omitted from this PR.

This also improves our msw stubs to handle more of the `objectTypeWithAllPropertyTypes` objects.