### PR TITLE
Fix LocalDate/Timestamp unintentional backcompat break

### DIFF
--- a/.changeset/red-keys-repeat.md
+++ b/.changeset/red-keys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@osdk/legacy-client": patch
+---
+
+Go back to typescript private instead of #private for localDate and timestamp dateTime member

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/loadObjects.test.ts
@@ -138,6 +138,7 @@ describe("LoadObjects", () => {
     expect(firstPoint).toMatchInlineSnapshot(`
       {
         "time": _Timestamp {
+          "dateTime": "2012-02-12T00:00:00.000Z",
           "type": "Timestamp",
         },
         "value": 10,
@@ -148,6 +149,7 @@ describe("LoadObjects", () => {
     expect(lastPoint).toMatchInlineSnapshot(`
       {
         "time": _Timestamp {
+          "dateTime": "2014-04-14T00:00:00.000Z",
           "type": "Timestamp",
         },
         "value": 30,
@@ -221,6 +223,7 @@ describe("LoadObjects", () => {
           "fullName": "Jane Doe",
           "office": "SEA",
           "startDate": _LocalDate {
+            "dateTime": "2012-02-12T00:00:00.000Z",
             "type": "LocalDate",
           },
         },

--- a/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
+++ b/packages/foundry-sdk-generator/src/__e2e_tests__/search.test.ts
@@ -97,6 +97,7 @@ describe("SearchObjects", () => {
           "fullName": "John Doe",
           "office": "NYC",
           "startDate": _LocalDate {
+            "dateTime": "2019-01-01T00:00:00.000Z",
             "type": "LocalDate",
           },
         },
@@ -127,6 +128,7 @@ describe("SearchObjects", () => {
           "fullName": "Jane Doe",
           "office": "SEA",
           "startDate": _LocalDate {
+            "dateTime": "2012-02-12T00:00:00.000Z",
             "type": "LocalDate",
           },
         },
@@ -157,6 +159,7 @@ describe("SearchObjects", () => {
           "fullName": "Jack Smith",
           "office": "LON",
           "startDate": _LocalDate {
+            "dateTime": "2015-05-15T00:00:00.000Z",
             "type": "LocalDate",
           },
         },
@@ -201,6 +204,7 @@ describe("SearchObjects", () => {
             "fullName": "John Doe",
             "office": "NYC",
             "startDate": _LocalDate {
+              "dateTime": "2019-01-01T00:00:00.000Z",
               "type": "LocalDate",
             },
           },
@@ -244,6 +248,7 @@ describe("SearchObjects", () => {
             "fullName": "John Doe",
             "office": "NYC",
             "startDate": _LocalDate {
+              "dateTime": "2019-01-01T00:00:00.000Z",
               "type": "LocalDate",
             },
           },
@@ -326,6 +331,7 @@ describe("SearchObjects", () => {
               "fullName": "Jane Doe",
               "office": "SEA",
               "startDate": _LocalDate {
+                "dateTime": "2012-02-12T00:00:00.000Z",
                 "type": "LocalDate",
               },
             },

--- a/packages/legacy-client/src/client/baseTypes/localDate.ts
+++ b/packages/legacy-client/src/client/baseTypes/localDate.ts
@@ -59,7 +59,7 @@ export class LocalDate {
   }
 
   // Internally represent the date as start of day (UTC).
-  #dateTime: DateTime;
+  private dateTime: DateTime;
 
   /**
    * Represents a date as year-month-day.
@@ -70,42 +70,42 @@ export class LocalDate {
    * @param day day of month, from 1 to 31
    */
   private constructor(year: number, month: number, day: number) {
-    this.#dateTime = DateTime.utc(year, month, day);
+    this.dateTime = DateTime.utc(year, month, day);
   }
 
   /**
    * Gets the year (YYYY) field.
    */
   getYear(): number {
-    return this.#dateTime.year;
+    return this.dateTime.year;
   }
 
   /**
    * Gets the month field (1-12).
    */
   getMonth(): number {
-    return this.#dateTime.month;
+    return this.dateTime.month;
   }
 
   /**
    * Gets the day field (1-31).
    */
   getDayOfMonth(): number {
-    return this.#dateTime.day;
+    return this.dateTime.day;
   }
 
   /**
    * Convert to ISO 8601 string (YYYY-MM-dd).
    */
   toISOString(): string {
-    return this.#dateTime.toISODate()!;
+    return this.dateTime.toISODate()!;
   }
 
   /**
    * Gets the ISO day of the week, where Monday = 1 and Sunday = 7.
    */
   getISOWeekday(): number {
-    return this.#dateTime.weekday;
+    return this.dateTime.weekday;
   }
 
   /**
@@ -126,7 +126,7 @@ export class LocalDate {
     // parse offset into the equivalent UTC offset zone
     const zone = FixedOffsetZone.parseSpecifier("UTC" + utcOffset);
     // manipulate the date time - override the zone keeping the local time constant (midnight)
-    const dateTimeWithOverriddenZone = this.#dateTime.setZone(zone, {
+    const dateTimeWithOverriddenZone = this.dateTime.setZone(zone, {
       keepLocalTime: true,
     });
     return Timestamp.fromISOString(dateTimeWithOverriddenZone.toISO()!);
@@ -151,7 +151,7 @@ export class LocalDate {
    */
   minusDays(daysToSubtract: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.minus(Duration.fromObject({ days: daysToSubtract })),
+      this.dateTime.minus(Duration.fromObject({ days: daysToSubtract })),
     );
   }
 
@@ -160,7 +160,7 @@ export class LocalDate {
    */
   minusWeeks(weeksToSubtract: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.minus(Duration.fromObject({ weeks: weeksToSubtract })),
+      this.dateTime.minus(Duration.fromObject({ weeks: weeksToSubtract })),
     );
   }
 
@@ -171,7 +171,7 @@ export class LocalDate {
    */
   minusMonths(monthsToSubtract: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.minus(Duration.fromObject({ months: monthsToSubtract })),
+      this.dateTime.minus(Duration.fromObject({ months: monthsToSubtract })),
     );
   }
 
@@ -180,7 +180,7 @@ export class LocalDate {
    */
   minusYears(yearsToSubtract: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.minus(Duration.fromObject({ years: yearsToSubtract })),
+      this.dateTime.minus(Duration.fromObject({ years: yearsToSubtract })),
     );
   }
 
@@ -189,7 +189,7 @@ export class LocalDate {
    */
   plusDays(daysToAdd: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.plus(Duration.fromObject({ days: daysToAdd })),
+      this.dateTime.plus(Duration.fromObject({ days: daysToAdd })),
     );
   }
 
@@ -198,7 +198,7 @@ export class LocalDate {
    */
   plusWeeks(weeksToAdd: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.plus(Duration.fromObject({ weeks: weeksToAdd })),
+      this.dateTime.plus(Duration.fromObject({ weeks: weeksToAdd })),
     );
   }
 
@@ -209,7 +209,7 @@ export class LocalDate {
    */
   plusMonths(monthsToAdd: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.plus(Duration.fromObject({ months: monthsToAdd })),
+      this.dateTime.plus(Duration.fromObject({ months: monthsToAdd })),
     );
   }
 
@@ -218,7 +218,7 @@ export class LocalDate {
    */
   plusYears(yearsToAdd: number): LocalDate {
     return LocalDate.fromDateTime(
-      this.#dateTime.plus(Duration.fromObject({ years: yearsToAdd })),
+      this.dateTime.plus(Duration.fromObject({ years: yearsToAdd })),
     );
   }
 }

--- a/packages/legacy-client/src/client/baseTypes/timestamp.ts
+++ b/packages/legacy-client/src/client/baseTypes/timestamp.ts
@@ -61,73 +61,70 @@ export class Timestamp {
     return new Timestamp(DateTime.fromJSDate(date, { zone: "utc" }));
   }
 
-  #dateTime: DateTime;
-
-  private constructor(dateTime: DateTime) {
-    this.#dateTime = dateTime;
+  private constructor(private dateTime: DateTime) {
   }
 
   /**
    * Gets year in the current timezone offset.
    */
   getYear(): number {
-    return this.#dateTime.year;
+    return this.dateTime.year;
   }
 
   /**
    * Gets month (1-12) in the current timezone offset.
    */
   getMonth(): number {
-    return this.#dateTime.month;
+    return this.dateTime.month;
   }
 
   /**
    * Gets day of month (1-31) in the current timezone offset.
    */
   getDayOfMonth(): number {
-    return this.#dateTime.day;
+    return this.dateTime.day;
   }
 
   /**
    * Gets hours (0-23) in the current timezone offset.
    */
   getHours(): number {
-    return this.#dateTime.hour;
+    return this.dateTime.hour;
   }
 
   /**
    * Gets minutes (0-59) in the current timezone offset.
    */
   getMinutes(): number {
-    return this.#dateTime.minute;
+    return this.dateTime.minute;
   }
 
   /**
    * Gets seconds (0-59) in the current timezone offset.
    */
   getSeconds(): number {
-    return this.#dateTime.second;
+    return this.dateTime.second;
   }
 
   /**
    * Gets milliseconds (0-999) in the current timezone offset.
    */
   getMilliseconds(): number {
-    return this.#dateTime.millisecond;
+    return this.dateTime.millisecond;
   }
 
   /**
    * A time-zone offset from Greenwich/UTC in minutes.
    */
   getTimezoneOffset(): number {
-    return this.#dateTime.offset;
+    return this.dateTime.offset;
   }
 
   /**
    * Gets milliseconds from epoch.
    */
   getTime(): number {
-    return this.#dateTime.valueOf();
+    return this.dateTime.valueOf();
   }
 
   /**
@@ -148,7 +145,7 @@ export class Timestamp {
    * Returns a javascript Date for the same instant in time.
    */
   toJsDate(): Date {
-    return this.#dateTime.toJSDate();
+    return this.dateTime.toJSDate();
   }
 
   /**
@@ -163,14 +160,14 @@ export class Timestamp {
    * The timezone-offset is maintained.
    */
   toISOString(): string {
-    return this.#dateTime.toISO()!;
+    return this.dateTime.toISO()!;
   }
 
   /**
    * Returns new Timestamp with milliseconds subtracted from it.
    */
   minusMilliseconds(millisecondsToSubtract: number): Timestamp {
-    return new Timestamp(this.#dateTime.minus(millisecondsToSubtract));
+    return new Timestamp(this.dateTime.minus(millisecondsToSubtract));
   }
 
   /**
@@ -178,7 +175,7 @@ export class Timestamp {
    */
   minusSeconds(secondsToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ seconds: secondsToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -186,7 +183,7 @@ export class Timestamp {
    */
   minusMinutes(minutesToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ minutes: minutesToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -194,7 +191,7 @@ export class Timestamp {
    */
   minusHours(hoursToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ hours: hoursToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -202,7 +199,7 @@ export class Timestamp {
    */
   minusDays(daysToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ days: daysToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -210,7 +207,7 @@ export class Timestamp {
    */
   minusWeeks(weeksToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ weeks: weeksToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -220,7 +217,7 @@ export class Timestamp {
    */
   minusMonths(monthsToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ months: monthsToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -228,7 +225,7 @@ export class Timestamp {
    */
   minusYears(yearsToSubtract: number): Timestamp {
     const duration = Duration.fromObject({ years: yearsToSubtract });
-    return new Timestamp(this.#dateTime.minus(duration));
+    return new Timestamp(this.dateTime.minus(duration));
   }
 
   /**
@@ -236,7 +233,7 @@ export class Timestamp {
    */
   plusMilliseconds(millisecondsToAdd: number): Timestamp {
     const duration = Duration.fromObject({ milliseconds: millisecondsToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -244,7 +241,7 @@ export class Timestamp {
    */
   plusSeconds(secondsToAdd: number): Timestamp {
     const duration = Duration.fromObject({ seconds: secondsToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -252,7 +249,7 @@ export class Timestamp {
    */
   plusMinutes(minutesToAdd: number): Timestamp {
     const duration = Duration.fromObject({ minutes: minutesToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -260,7 +257,7 @@ export class Timestamp {
    */
   plusHours(hoursToAdd: number): Timestamp {
     const duration = Duration.fromObject({ hours: hoursToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -268,7 +265,7 @@ export class Timestamp {
    */
   plusDays(daysToAdd: number): Timestamp {
     const duration = Duration.fromObject({ days: daysToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -276,7 +273,7 @@ export class Timestamp {
    */
   plusWeeks(weeksToAdd: number): Timestamp {
     const duration = Duration.fromObject({ weeks: weeksToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -286,7 +283,7 @@ export class Timestamp {
    */
   plusMonths(monthsToAdd: number): Timestamp {
     const duration = Duration.fromObject({ months: monthsToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 
   /**
@@ -294,6 +291,6 @@ export class Timestamp {
    */
   plusYears(yearsToAdd: number): Timestamp {
     const duration = Duration.fromObject({ years: yearsToAdd });
-    return new Timestamp(this.#dateTime.plus(duration));
+    return new Timestamp(this.dateTime.plus(duration));
   }
 }


### PR DESCRIPTION
We moved dateTime from typescript private to #private, which changed the enforcement semantics. This change puts it back to the original implementation.