### PR TITLE
Better foundry-sdk-generator error handling

### DIFF
--- a/.changeset/fast-taxis-behave.md
+++ b/.changeset/fast-taxis-behave.md
@@ -1,0 +1,5 @@
+---
+"@osdk/foundry-sdk-generator": patch
+---
+
+Better error handling around server errors when getting ontology metadata

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -131,6 +131,14 @@ export class OntologyMetadataResolver {
       ontology.apiName,
     );
 
+    if ((ontologyFullMetadata as any).errorName != null) {
+      return Result.err([
+        `Unable to load the specified Ontology metadata.\n${
+          JSON.stringify(ontologyFullMetadata, null, 2)
+        }`,
+      ]);
+    }
+
     const linkTypes = new Map<string, Set<string>>();
     const objectTypes = new Set(
       entities.objectTypesApiNamesToLoad?.map(object => object.toLowerCase()),


### PR DESCRIPTION
Check server's metadata to make sure it isn't an error before we start operating on it.

Suspect that this might be hiding some of the root causes for build failures we've had in the past.