### PR TITLE
Include OSDK package and foundry-sdk-generator in user agent

### DIFF
--- a/.changeset/fast-fans-film.md
+++ b/.changeset/fast-fans-film.md
@@ -1,0 +1,10 @@
+---
+"@osdk/foundry-sdk-generator": patch
+"@osdk/legacy-client": patch
+"@osdk/shared.net": patch
+"@osdk/generator": patch
+"@osdk/client": patch
+"@osdk/cli": patch
+---
+
+Include OSDK package and foundry-sdk-generator in user agent

--- a/packages/cli/src/commands/typescript/generate/handleGenerate.mts
+++ b/packages/cli/src/commands/typescript/generate/handleGenerate.mts
@@ -70,7 +70,7 @@ async function generateFromStack(args: TypescriptGenerateArgs) {
   const { fetch } = createClientContext(
     {
       metadata: {
-        userAgent: "@osdk/cli/0.0.0 ()",
+        userAgent: "@osdk/cli/0.0.0",
       },
     },
     args.stack!,

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -32,7 +32,7 @@ export function createClient<O extends OntologyDefinition<any>>(
     ontology,
     stack,
     tokenProvider,
-    "@osdk/client/0.0.0 ()",
+    "@osdk/client/0.0.0",
     fetchFn,
   );
 

--- a/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
+++ b/packages/generator/src/v1.1/generateClientSdkVersionOneDotOne.ts
@@ -37,6 +37,7 @@ export async function generateClientSdkVersionOneDotOne(
   fs: MinimalFs,
   outDir: string,
   packageType: "commonjs" | "module" = "commonjs",
+  additionalUserAgents: string[] = [],
 ) {
   const importExt = packageType === "module" ? ".js" : "";
   const objectsDir = path.join(outDir, "ontology", "objects");
@@ -47,7 +48,13 @@ export async function generateClientSdkVersionOneDotOne(
 
   const sanitizedOntology = sanitizeMetadata(ontology);
   await generateFoundryClientFile(fs, outDir, importExt);
-  await generateMetadataFile(sanitizedOntology, fs, outDir, importExt);
+  await generateMetadataFile(
+    sanitizedOntology,
+    fs,
+    outDir,
+    importExt,
+    additionalUserAgents,
+  );
   await generateOntologyIndexFile(
     fs,
     path.join(outDir, "ontology"),

--- a/packages/generator/src/v1.1/generateMetadataFile.test.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.test.ts
@@ -277,4 +277,68 @@ describe(generateMetadataFile, () => {
       "
     `);
   });
+
+  it("handles additional user agents", async () => {
+    const helper = createMockMinimalFiles();
+    const BASE_PATH = "/foo";
+
+    await generateMetadataFile(
+      {
+        ontology: {
+          apiName: "apiName",
+          displayName: "",
+          description: "",
+          rid: "rid",
+        },
+        objectTypes: {},
+        actionTypes: {},
+        queryTypes: {},
+        interfaceTypes: {},
+        sharedPropertyTypes: {},
+      },
+      helper.minimalFiles,
+      BASE_PATH,
+      undefined,
+      ["foo/1.0.0", "bar/2.0.0"],
+    );
+
+    expect(helper.minimalFiles.writeFile).toBeCalled();
+
+    expect(
+      helper.getFiles()[`${BASE_PATH}/Ontology.ts`],
+    ).toMatchInlineSnapshot(`
+        "import type { OntologyDefinition } from '@osdk/api';
+        import type { Ontology as ClientOntology } from '@osdk/legacy-client';
+        import type { Actions } from './ontology/actions/Actions';
+        import type { Objects } from './ontology/objects/Objects';
+        import type { Queries } from './ontology/queries/Queries';
+
+        export const Ontology: {
+          metadata: {
+            ontologyRid: 'rid';
+            ontologyApiName: 'apiName';
+            userAgent: 'foundry-typescript-osdk/0.0.1 foo/1.0.0 bar/2.0.0';
+          };
+          objects: {};
+          actions: {};
+          queries: {};
+        } = {
+          metadata: {
+            ontologyRid: 'rid' as const,
+            ontologyApiName: 'apiName' as const,
+            userAgent: 'foundry-typescript-osdk/0.0.1 foo/1.0.0 bar/2.0.0' as const,
+          },
+          objects: {},
+          actions: {},
+          queries: {},
+        } satisfies OntologyDefinition<never, never, never>;
+        
+        export interface Ontology extends ClientOntology<typeof Ontology> {
+          objects: Objects;
+          actions: Actions;
+          queries: Queries;
+        }
+        "
+      `);
+  });
 });

--- a/packages/generator/src/v1.1/generateMetadataFile.ts
+++ b/packages/generator/src/v1.1/generateMetadataFile.ts
@@ -26,6 +26,7 @@ export async function generateMetadataFile(
   fs: MinimalFs,
   outDir: string,
   importExt: string = "",
+  additionalUserAgents: string[] = [],
 ) {
   const objectNames = Object.keys(ontology.objectTypes);
   const actionNames = Object.keys(ontology.actionTypes);
@@ -60,6 +61,9 @@ export async function generateMetadataFile(
       return name;
     }
   };
+
+  const userAgent = ["foundry-typescript-osdk/0.0.1", ...additionalUserAgents]
+    .join(" ");
 
   await fs.writeFile(
     path.join(outDir, "Ontology.ts"),
@@ -97,7 +101,7 @@ export async function generateMetadataFile(
     metadata: {
       ontologyRid: "${ontology.ontology.rid}",
       ontologyApiName: "${ontology.ontology.apiName}",
-      userAgent: "foundry-typescript-osdk/0.0.1",
+      userAgent: "${userAgent}",
     },
     objects: {
       ${commaSeparatedTypeIdentifiers(objectNames)}
@@ -112,7 +116,7 @@ export async function generateMetadataFile(
     metadata: {
         ontologyRid: "${ontology.ontology.rid}" as const,
         ontologyApiName: "${ontology.ontology.apiName}" as const,
-        userAgent: "foundry-typescript-osdk/0.0.1" as const,
+        userAgent: "${userAgent}" as const,
     },
     objects: {
         ${commaSeparatedIdentifiers(objectNames)}

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -30,6 +30,8 @@ describe("generator", () => {
       TodoWireOntology,
       helper.minimalFiles,
       BASE_PATH,
+      undefined,
+      ["foo/1.0.0"],
     );
 
     const files = helper.getFiles();

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -30,6 +30,7 @@ export async function generateClientSdkVersionTwoPointZero(
   fs: MinimalFs,
   outDir: string,
   packageType: "module" | "commonjs" = "commonjs",
+  additionalUserAgents: string[] = [],
 ) {
   await verifyOutdir(outDir, fs);
 
@@ -54,7 +55,12 @@ export async function generateClientSdkVersionTwoPointZero(
     ),
   );
 
-  await generateOntologyMetadataFile(sanitizedOntology, fs, outDir);
+  await generateOntologyMetadataFile(
+    sanitizedOntology,
+    fs,
+    outDir,
+    additionalUserAgents,
+  );
 
   await fs.writeFile(
     path.join(outDir, "Ontology.ts"),

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -23,7 +23,10 @@ export async function generateOntologyMetadataFile(
   ontology: WireOntologyDefinition,
   fs: MinimalFs,
   outDir: string,
+  additionalUserAgents: string[] = [],
 ) {
+  const userAgent = ["foundry-typescript-osdk/2.0.0", ...additionalUserAgents]
+    .join(" ");
   fs.writeFile(
     path.join(outDir, "OntologyMetadata.ts"),
     await formatTs(
@@ -31,7 +34,7 @@ export async function generateOntologyMetadataFile(
       export const OntologyMetadata = {
         ontologyRid: "${ontology.ontology.rid}",
         ontologyApiName: "${ontology.ontology.apiName}",
-        userAgent: "foundry-typescript-osdk/2.0.0",
+        userAgent: "${userAgent}",
       }
       `,
     ),

--- a/packages/legacy-client/src/USER_AGENT.ts
+++ b/packages/legacy-client/src/USER_AGENT.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const USER_AGENT = "@osdk/legacy-client/0.0.0 ()";
+export const USER_AGENT = "@osdk/legacy-client/0.0.0";

--- a/packages/shared.net/src/createClientContext.ts
+++ b/packages/shared.net/src/createClientContext.ts
@@ -31,23 +31,25 @@ export function createClientContext<
   ontology: T,
   stack: string,
   tokenProvider: () => Promise<string> | string,
-  additionalUserAgent?: `${string} (${string})`,
+  additionalUserAgent?: string,
   fetchFn: typeof globalThis.fetch = fetch,
 ): ClientContext<T> {
   if (stack.length === 0) {
     throw new Error("stack cannot be empty");
   }
+
+  const userAgent = [
+    "@osdk/shared.net/0.0.0",
+    additionalUserAgent,
+    ontology.metadata.userAgent,
+  ].filter(s => s != null).join(" ");
+
   const retryingFetchWithAuthOrThrow = createFetchHeaderMutator(
     createRetryingFetch(createFetchOrThrow(fetchFn)),
     async (headers) => {
       const token = await tokenProvider();
       headers.set("Authorization", `Bearer ${token}`);
-      headers.set(
-        "Fetch-User-Agent",
-        `@osdk/shared.net/0.0.0 () ${
-          additionalUserAgent ? additionalUserAgent + " " : ""
-        }${ontology.metadata.userAgent}`,
-      );
+      headers.set("Fetch-User-Agent", userAgent);
       return headers;
     },
   );


### PR DESCRIPTION
Currently there is no information in the user agent identifying the OSDK package name/version or the OSDK generator version being used. We get information only about whether the package was generated using 1.1 or 2.0.

Old example in 1.1's generated ontology metadata:

```
userAgent: foundry-typescript-osdk/0.0.1
```

After this PR we include the OSDK package name/version and the `@osdk/foundry-sdk-generator` version.

New example in foundry-sdk-generator's src/generatedNoCheck ontology:

```
userAgent: 'foundry-typescript-osdk/0.0.1 @test-app/osdk/0.0.1 @osdk/foundry-sdk-generator/0.200.6',
```

I also removed the empty `()` parts of user agents as we don't actually add any additional information. I considered if we should pass this information through to `createClientContext` directly rather than through the ontology but I don't think that works well in 2.0 where the user is expected to call generic `createClient` with just the ontology metadata so the ontology metadata itself must contain this information.