### PR TITLE
[1/] Improvement: Add utility functions for CLI improvements

### DIFF
--- a/packages/cli/src/utils/configFileUtils.ts
+++ b/packages/cli/src/utils/configFileUtils.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { promises as fsPromises } from "node:fs";
+
+interface SiteConfig {
+  application: string;
+  foundryUrl: string;
+  directory: string;
+  autoVersion?: boolean;
+}
+
+interface ConfigJson {
+  site: SiteConfig;
+}
+
+const CONFIG_FILE_NAMES: string[] = [
+  "foundry.config.json",
+];
+
+/**
+ * Asynchronously loads a configuration file. Looks for any of the CONFIG_FILE_NAMES in the current directory going up to the root directory.
+ * @returns A promise that resolves to the configuration JSON object, or undefined if not found.
+ * @throws Will throw an error if the configuration file is found but cannot be read or parsed.
+ */
+export async function loadConfigFile(): Promise<ConfigJson | undefined> {
+  const Consola = await import("consola");
+  const consola = Consola.consola;
+  const { findUp } = await import("find-up");
+
+  for (const configFileName of CONFIG_FILE_NAMES) {
+    const result = await findUp(configFileName, { cwd: process.cwd() });
+    if (result) {
+      try {
+        const fileContent = await fsPromises.readFile(result, "utf-8");
+        const configJson: ConfigJson = JSON.parse(fileContent);
+        return configJson;
+      } catch (error) {
+        consola.error(
+          "Error reading or parsing the configuration file:",
+          error,
+        );
+        throw error;
+      }
+    }
+  }
+
+  consola.warn(
+    `A config file wasn't found. Falling back to command line arguments.`,
+  );
+  return undefined;
+}
+
+/**
+ * Extracts and validates the site configuration object from the configuration JSON object.
+ * @param configJson The configuration JSON object.
+ * @returns The site configuration object.
+ */
+export function extractSiteConfig(configJson: ConfigJson): SiteConfig {
+  const siteConfig = configJson.site;
+  validateSiteConfig(siteConfig);
+  return siteConfig;
+}
+
+/**
+ * Validates the site configuration object.
+ * @param siteConfig The site configuration object to validate.
+ * @throws Will throw an error if the site configuration is invalid.
+ */
+function validateSiteConfig(siteConfig: SiteConfig): void {
+  if (!siteConfig) {
+    throw new Error("Could not find a site entry in the config file.");
+  }
+
+  const requiredKeys: (keyof SiteConfig)[] = [
+    "application",
+    "foundryUrl",
+    "directory",
+  ];
+  const missingKeys = requiredKeys.filter((key) => !siteConfig[key]);
+
+  if (missingKeys.length > 0) {
+    throw new Error(
+      `Missing required keys in site config: ${missingKeys.join(", ")}`,
+    );
+  }
+}

--- a/packages/cli/src/utils/tokenFileUtils.ts
+++ b/packages/cli/src/utils/tokenFileUtils.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Synchronously reads a JWT Auth Token from a file.
+ * @param filePath The path to the token file.
+ * @returns The token as a string.
+ */
+export function loadToken(filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+  const token = fs.readFileSync(resolvedPath, "utf8").trim();
+
+  if (!isJWT(token)) {
+    throw new Error(`Token file ${resolvedPath} does not contain a valid JWT`);
+  }
+
+  return token;
+}
+
+/**
+ * Checks if a given string is a JWT.
+ * @param token The string to check.
+ * @returns true if the string is a JWT, false otherwise.
+ */
+function isJWT(token: string): boolean {
+  // https://stackoverflow.com/a/65755789
+  const jwtPattern = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
+  return jwtPattern.test(token);
+}

--- a/packages/cli/src/utils/versionUtils.ts
+++ b/packages/cli/src/utils/versionUtils.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execSync } from "node:child_process";
+import { promises as fsPromises } from "node:fs";
+
+/**
+ * Gets the version string using git describe or falls back to package.json version.
+ * @param prefix The prefix to use for matching against tags. Defaults to an empty string.
+ * @returns A promise that resolves to the version string. Throws an error if the version string is not SemVer compliant or if the version cannot be determined.
+ * @throws An error if the version string is not SemVer compliant or if the version cannot be determined.
+ */
+export async function getAutoVersion(prefix: string = ""): Promise<string> {
+  const { findUp } = await import("find-up");
+
+  try {
+    const gitVersion = execSync(
+      `git describe --tags --always --first-parent --match="${prefix}*"`,
+      { encoding: "utf8" },
+    );
+    const version = gitVersion.trim().replace(prefix, "");
+
+    if (!isSemVerCompliant(version)) {
+      throw new Error(`The version string ${version} is not SemVer compliant.`); // Will fall back to package.json version
+    }
+
+    return version;
+  } catch {
+    // If git describe fails, find the nearest package.json and use its version
+    const packageJsonPath = await findUp("package.json");
+    if (packageJsonPath) {
+      const packageJsonContent = await fsPromises.readFile(
+        packageJsonPath,
+        "utf-8",
+      );
+      const packageJson = JSON.parse(packageJsonContent);
+      if (packageJson.version && isSemVerCompliant(packageJson.version)) {
+        return packageJson.version;
+      }
+    }
+
+    throw new Error(
+      "Unable to determine the version automatically. Please supply a --version argument.",
+    );
+  }
+}
+
+/**
+ * Checks if a given version string is SemVer compliant.
+ * @param version The version string to check.
+ * @returns true if the version string is SemVer compliant, false otherwise.
+ */
+function isSemVerCompliant(version: string): boolean {
+  //  https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  const semVerRegex =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+  return semVerRegex.test(version);
+}


### PR DESCRIPTION
Part of an effort to improve the osdk cli. 
The work to get the improvements across will be done over the followings PRs:
[1/] [Add new utility functions ](https://github.com/ericanderson/osdk-ts/pull/227)  --> this
[2/] [Introduce new command structure](https://github.com/zeyadkhaled/osdk-ts/pull/1)
[3/] Make the commands depend on token being passed explicitly

## This PR
Introduces 3 utility functions that will assist with the CLI improvements.

- configFileUtils -> Project config file loading and validating
- versionUtils -> For autoVersioning capabilities 
- tokenFileUtils -> Loading token file containing JWT tokens used for Auth


## Considerations

- Adding tests for each of the utility tools. Should that be part of a local tests sub-package within the CLI package?\
- Licensing information is set to 2023 instead of 2024